### PR TITLE
Update(enhance documentation and small fix)

### DIFF
--- a/include/bzp/Utils.h
+++ b/include/bzp/Utils.h
@@ -193,16 +193,16 @@ struct Utils
 	static constexpr uint8_t endianToHci(uint8_t value) noexcept {return value;}
 
 	// Convert a 16-bit value from HCI format to host format
-	static constexpr uint16_t endianToHost(uint16_t value) noexcept {return le16toh(value);}
+	static uint16_t endianToHost(uint16_t value) noexcept {return le16toh(value);}
 
 	// Convert a 16-bit value from host format to HCI format
-	static constexpr uint16_t endianToHci(uint16_t value) noexcept {return htole16(value);}
+	static uint16_t endianToHci(uint16_t value) noexcept {return htole16(value);}
 
 	// Convert a 32-bit value from HCI format to host format
-	static constexpr uint32_t endianToHost(uint32_t value) noexcept {return le32toh(value);}
+	static uint32_t endianToHost(uint32_t value) noexcept {return le32toh(value);}
 
 	// Convert a 32-bit value from host format to HCI format
-	static constexpr uint32_t endianToHci(uint32_t value) noexcept {return htole32(value);}
+	static uint32_t endianToHci(uint32_t value) noexcept {return htole32(value);}
 
 	// -----------------------------------------------------------------------------------------------------------------------------
 	// BlueZ name truncation utilities (moved from deprecated Mgmt class)

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -135,7 +135,7 @@ std::string Utils::hex(const uint8_t *pData, int count)
 	std::vector<std::string> hexData;
 	for (int i = 0; i < count; ++i)
 	{
-		line += std::format("{:02X} ", pData[i]);
+		line += safeFormat("{:02X} ", pData[i]);
 
 		if (line.length() >= 16 * 3)
 		{


### PR DESCRIPTION
# Updates

 - Remove constexpr from endian conversion functions (3d5d009)
    - Removed constexpr keyword from endianToHost() and endianToHci() functions in Utils.h
    - The le16toh(), htole16(), le32toh(), htole32() macros are not constexpr-compatible
    - Fixes compilation issues on certain platforms while maintaining functionality
  - Replace std::format with safeFormat (37b22eb)
    - Changed Utils::hex() to use safeFormat() instead of std::format
    - Improves compatibility across different C++20 implementations
    - Leverages the existing FormatCompat layer for better portability

  - Major README improvements (e157df1)
    - Added quick-start configuration steps for D-Bus and BlueZ setup
    - Reorganized documentation into clear user/developer/technical sections
    - Expanded D-Bus permission documentation:
        - Manual installation instructions for source builds
      - Detailed troubleshooting guide with common issues
      - Service name requirements and path structure examples
      - D-Bus policy file explanation
    - Added links to all technical documentation (BUILD.md, STANDALONE_USAGE.md, etc.)
    - Improved configuration troubleshooting section