### PR TITLE
Fix on arm64 runner

### DIFF
--- a/.github/workflows/apt-publish.yml
+++ b/.github/workflows/apt-publish.yml
@@ -36,6 +36,9 @@ jobs:
             use_container: false
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.use_container && 'debian:bookworm' || null }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -117,6 +120,9 @@ jobs:
     name: Sign and publish APT repo
     needs: build
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Download amd64 repo fragment
         uses: actions/download-artifact@v4

--- a/.github/workflows/apt-publish.yml
+++ b/.github/workflows/apt-publish.yml
@@ -29,24 +29,34 @@ jobs:
           - arch: amd64
             runner: ubuntu-latest
             deb_arch: amd64
-            container: debian:bookworm
+            use_container: true
           - arch: arm64
             runner: [self-hosted, Linux, ARM64]
             deb_arch: arm64
-            container: debian:bookworm
+            use_container: false
     runs-on: ${{ matrix.runner }}
-    container: ${{ matrix.container }}
+    container: ${{ matrix.use_container && 'debian:bookworm' || null }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install build dependencies
         run: |
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            build-essential cmake pkg-config debhelper \
-            dpkg-dev apt-utils gnupg apt-transport-https ca-certificates \
-            libglib2.0-dev libbluetooth-dev bluez bluez-tools git
+          if [ "${{ matrix.use_container }}" = "true" ]; then
+            # Inside container (already root)
+            apt-get update
+            apt-get install -y --no-install-recommends \
+              build-essential cmake pkg-config debhelper \
+              dpkg-dev apt-utils gnupg apt-transport-https ca-certificates \
+              libglib2.0-dev libbluetooth-dev bluez bluez-tools git
+          else
+            # On self-hosted runner (need sudo)
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends \
+              build-essential cmake pkg-config debhelper \
+              dpkg-dev apt-utils gnupg apt-transport-https \
+              libglib2.0-dev libbluetooth-dev bluez bluez-tools
+          fi
 
       - name: Determine version from tag or release
         id: get_version
@@ -69,7 +79,11 @@ jobs:
 
       - name: Install lintian and check package quality
         run: |
-          apt-get install -y lintian
+          if [ "${{ matrix.use_container }}" = "true" ]; then
+            apt-get install -y lintian
+          else
+            sudo apt-get install -y lintian
+          fi
           echo "::group::Lintian Package Quality Check"
           for deb in packages/*.deb; do
             if [ -f "$deb" ]; then

--- a/.github/workflows/apt-publish.yml
+++ b/.github/workflows/apt-publish.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install lintian and check package quality
         run: |
-          sudo apt-get install -y lintian
+          apt-get install -y lintian
           echo "::group::Lintian Package Quality Check"
           for deb in packages/*.deb; do
             if [ -f "$deb" ]; then

--- a/.github/workflows/apt-publish.yml
+++ b/.github/workflows/apt-publish.yml
@@ -29,21 +29,24 @@ jobs:
           - arch: amd64
             runner: ubuntu-latest
             deb_arch: amd64
+            container: debian:bookworm
           - arch: arm64
             runner: [self-hosted, Linux, ARM64]
             deb_arch: arm64
+            container: debian:bookworm
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          apt-get update
+          apt-get install -y --no-install-recommends \
             build-essential cmake pkg-config debhelper \
-            dpkg-dev apt-utils gnupg apt-transport-https \
-            libglib2.0-dev libbluetooth-dev bluez bluez-tools
+            dpkg-dev apt-utils gnupg apt-transport-https ca-certificates \
+            libglib2.0-dev libbluetooth-dev bluez bluez-tools git
 
       - name: Determine version from tag or release
         id: get_version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,23 +95,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang
     endif()
 endif()
 
-# Check for std::format availability
-include(CheckCXXSourceCompiles)
-check_cxx_source_compiles("
-    #include <format>
-    #include <string>
-    int main() {
-        std::string result = std::format(\"test {}\", 42);
-        return 0;
-    }
-" HAS_STD_FORMAT)
-
-if(HAS_STD_FORMAT)
-    add_compile_definitions(HAS_STD_FORMAT=1)
-else()
-    add_compile_definitions(HAS_STD_FORMAT=0)
-    message(STATUS "std::format not available, using fallback implementation")
-endif()
+# Force disable std::format for maximum compatibility with Debian 12 (GCC 12)
+# std::format requires GLIBCXX_3.4.31+ (GCC 13+) which is not available in Debian 12
+# Using snprintf fallback for broader compatibility across Debian/Ubuntu LTS versions
+add_compile_definitions(HAS_STD_FORMAT=0)
+message(STATUS "std::format disabled for Debian 12 compatibility (using snprintf fallback)")
 
 # Include directories
 include_directories(include)
@@ -314,8 +302,8 @@ if(NOT BZPERI_DEB_ARCH)
 endif()
 set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${BZPERI_DEB_ARCH}")
 
-# Dependencies
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.34), libgcc-s1 (>= 3.0), libstdc++6 (>= 11), libglib2.0-0 (>= 2.58), bluez (>= 5.42)")
+# Dependencies - Compatible with Debian 12 bookworm (GCC 12, GLIBCXX_3.4.30)
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.34), libgcc-s1 (>= 3.0), libstdc++6 (>= 12), libglib2.0-0 (>= 2.58), bluez (>= 5.42)")
 set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "bluez (>= 5.77)")
 set(CPACK_DEBIAN_PACKAGE_SUGGESTS "bluez-tools")
 


### PR DESCRIPTION
# Fix

  - GLIBCXX compatibility issues on Debian 12 and Ubuntu 22.04 LTS
  - Package dependencies now correctly reflect GCC 12 requirements