### PR TITLE
feat: add terminal-first standalone workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Verify executable
         run: |
-          # Verify the standalone binary exists, is executable, and prints its help text.
+          # Verify the standalone binary exists, is executable, and exposes the Phase 1 control-plane contract.
           test -x build/bzp-standalone
           echo "Executable exists"
           if command -v file >/dev/null 2>&1; then
@@ -102,8 +102,45 @@ jobs:
           else
             echo "Skipping 'file' inspection: utility not installed in this environment"
           fi
+
           build/bzp-standalone --help > /tmp/bzp-standalone-help.txt 2>&1
-          grep -q "Usage: standalone" /tmp/bzp-standalone-help.txt
+          grep -q "Usage: bzp-standalone <command>" /tmp/bzp-standalone-help.txt
+          grep -q "doctor" /tmp/bzp-standalone-help.txt
+          grep -q "inspect" /tmp/bzp-standalone-help.txt
+
+          build/bzp-standalone demo --help > /tmp/bzp-standalone-demo-help.txt 2>&1
+          grep -q "Usage: bzp-standalone demo" /tmp/bzp-standalone-demo-help.txt
+
+          build/bzp-standalone doctor --help > /tmp/bzp-standalone-doctor-help.txt 2>&1
+          grep -q "Usage: bzp-standalone doctor" /tmp/bzp-standalone-doctor-help.txt
+
+          build/bzp-standalone inspect --help > /tmp/bzp-standalone-inspect-help.txt 2>&1
+          grep -q "Usage: bzp-standalone inspect --live" /tmp/bzp-standalone-inspect-help.txt
+          grep -q -- "--show-tree" /tmp/bzp-standalone-inspect-help.txt
+
+          build/bzp-standalone --adapter=hci0 --help > /tmp/bzp-standalone-legacy-demo-help.txt 2>&1
+          grep -q "Usage: bzp-standalone demo" /tmp/bzp-standalone-legacy-demo-help.txt
+
+          if build/bzp-standalone nope > /tmp/bzp-standalone-invalid.txt 2>&1; then
+            echo "invalid subcommand unexpectedly succeeded"
+            exit 1
+          fi
+          grep -q "unknown subcommand" /tmp/bzp-standalone-invalid.txt
+
+          if build/bzp-standalone inspect --live > /tmp/bzp-standalone-no-session.txt 2>&1; then
+            echo "inspect --live unexpectedly succeeded without a managed session"
+            exit 1
+          fi
+          grep -q "No managed BzPeri session found" /tmp/bzp-standalone-no-session.txt
+
+          rm -rf /tmp/bzperi-stage
+          DESTDIR=/tmp/bzperi-stage cmake --install build
+          test -x /tmp/bzperi-stage/usr/local/bin/bzp-standalone
+          /tmp/bzperi-stage/usr/local/bin/bzp-standalone --help > /tmp/bzp-standalone-installed-help.txt 2>&1
+          grep -q "Usage: bzp-standalone <command>" /tmp/bzp-standalone-installed-help.txt
+          /tmp/bzperi-stage/usr/local/bin/bzp-standalone inspect --help > /tmp/bzp-standalone-installed-inspect-help.txt 2>&1
+          grep -q "Usage: bzp-standalone inspect --live" /tmp/bzp-standalone-installed-inspect-help.txt
+          grep -q -- "--show-tree" /tmp/bzp-standalone-installed-inspect-help.txt
 
   lint:
     name: Code Style Check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,10 +135,12 @@ jobs:
 
           rm -rf /tmp/bzperi-stage
           DESTDIR=/tmp/bzperi-stage cmake --install build
-          test -x /tmp/bzperi-stage/usr/local/bin/bzp-standalone
-          /tmp/bzperi-stage/usr/local/bin/bzp-standalone --help > /tmp/bzp-standalone-installed-help.txt 2>&1
+          export BZP_STAGE_ROOT=/tmp/bzperi-stage/usr/local
+          export LD_LIBRARY_PATH="$BZP_STAGE_ROOT/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          test -x "$BZP_STAGE_ROOT/bin/bzp-standalone"
+          "$BZP_STAGE_ROOT/bin/bzp-standalone" --help > /tmp/bzp-standalone-installed-help.txt 2>&1
           grep -q "Usage: bzp-standalone <command>" /tmp/bzp-standalone-installed-help.txt
-          /tmp/bzperi-stage/usr/local/bin/bzp-standalone inspect --help > /tmp/bzp-standalone-installed-inspect-help.txt 2>&1
+          "$BZP_STAGE_ROOT/bin/bzp-standalone" inspect --help > /tmp/bzp-standalone-installed-inspect-help.txt 2>&1
           grep -q "Usage: bzp-standalone inspect --live" /tmp/bzp-standalone-installed-inspect-help.txt
           grep -q -- "--show-tree" /tmp/bzp-standalone-installed-inspect-help.txt
 

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ REPORT.md
 # CLI
 CLAUDE.md
 AGENTS.md
+/.gstack/

--- a/BLUEZ_MIGRATION.md
+++ b/BLUEZ_MIGRATION.md
@@ -72,7 +72,8 @@ if (result.hasError()) {
 ### Root Access
 The application works with `sudo` out of the box:
 ```bash
-sudo ./build/bzp-standalone -d
+sudo ./build/bzp-standalone doctor
+sudo ./build/bzp-standalone demo -d
 ```
 
 ### Polkit Configuration
@@ -90,7 +91,7 @@ polkit.addRule(function(action, subject) {
 ```
 
 ### D-Bus Policy
-Ensure your existing `/etc/dbus-1/system.d/com.bzperi.conf` remains for service name ownership. BlueZ access is handled by polkit.
+Ensure the BzPeri D-Bus policy is installed for service-name ownership. Packaged installs place it at `/usr/share/dbus-1/system.d/com.bzperi.conf`; source builds can copy `dbus/com.bzperi.conf` into `/etc/dbus-1/system.d/`. BlueZ access is still handled by polkit.
 
 ## Feature Detection and Fallbacks
 
@@ -129,7 +130,7 @@ for (const auto& adapter : adapters.value()) {
 ```bash
 # Environment variable
 export BLUEZ_ADAPTER=hci1
-./build/bzp-standalone
+sudo ./build/bzp-standalone demo
 
 # Or programmatically
 adapter.initialize("hci1");  // or "/org/bluez/hci1"
@@ -222,7 +223,8 @@ busctl tree org.bluez
 ### Debug Information
 Enable debug logging to see detailed D-Bus operations:
 ```bash
-sudo ./build/bzp-standalone -d -v
+sudo ./build/bzp-standalone demo -d
+sudo ./build/bzp-standalone inspect --live --verbose-events
 ```
 
 Monitor D-Bus traffic:

--- a/BUILD.md
+++ b/BUILD.md
@@ -54,7 +54,7 @@ Modern CMake-based build system with cross-platform support:
 ```bash
 # Clone and setup
 git clone <repository-url>
-cd bzperi
+cd BzPeri
 
 # Create build directory
 mkdir build && cd build
@@ -116,8 +116,9 @@ sudo dbus-send --system --print-reply \
     --dest=org.bluez /org/bluez \
     org.freedesktop.DBus.Introspectable.Introspect
 
-# Run bzp-standalone example (requires sudo)
-sudo ./build/bzp-standalone -d
+# Check the host, then run the managed demo
+sudo ./build/bzp-standalone doctor
+sudo ./build/bzp-standalone demo -d
 ```
 
 ## Development Setup
@@ -145,7 +146,7 @@ cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON
 make -j$(nproc)
 
 # Run with debugging
-sudo gdb ./bzp-standalone
+sudo gdb --args ./bzp-standalone demo -d
 ```
 
 ## Platform-Specific Notes
@@ -157,6 +158,7 @@ sudo gdb ./bzp-standalone
   sudo cp dbus/com.bzperi.conf /etc/dbus-1/system.d/
   sudo systemctl reload dbus
   ```
+- Packaged installs place the same policy at `/usr/share/dbus-1/system.d/com.bzperi.conf`
 
 ### macOS
 - Bluetooth LE operations not supported (no BlueZ)
@@ -201,8 +203,8 @@ sudo apt install bluez bluez-tools
 sudo cp dbus/com.bzperi.conf /etc/dbus-1/system.d/
 sudo systemctl reload dbus
 
-# Or run with sudo
-sudo ./bzp-standalone
+# Then re-check the host
+sudo ./build/bzp-standalone doctor
 ```
 
 #### "std::format not available"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,8 +321,26 @@ endif()
 
 # Standalone executable
 if(BUILD_STANDALONE AND LINUX)
-    add_executable(standalone samples/standalone.cpp)
-    target_link_libraries(standalone bzperi)
+    add_executable(standalone
+        samples/standalone.cpp
+        src/StandaloneWorkflow.cpp
+    )
+    target_link_libraries(standalone
+        bzperi
+        ${GLIB_LIBRARIES}
+        ${GIO_LIBRARIES}
+        ${GOBJECT_LIBRARIES}
+    )
+    target_include_directories(standalone PRIVATE
+        ${GLIB_INCLUDE_DIRS}
+        ${GIO_INCLUDE_DIRS}
+        ${GOBJECT_INCLUDE_DIRS}
+    )
+    target_compile_options(standalone PRIVATE
+        ${GLIB_CFLAGS_OTHER}
+        ${GIO_CFLAGS_OTHER}
+        ${GOBJECT_CFLAGS_OTHER}
+    )
     set_target_properties(standalone PROPERTIES
         OUTPUT_NAME bzp-standalone
     )
@@ -335,6 +353,7 @@ if(BUILD_TESTING)
     if(LINUX)
         add_executable(bzperi-tests
             tests/bzperi_tests.cpp
+            src/StandaloneWorkflow.cpp
         )
         target_link_libraries(bzperi-tests PRIVATE
             bzperi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,9 @@ mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Debug
 make -j$(nproc)
 
-# Run example (requires sudo for BlueZ access)
-sudo ./bzp-standalone -d
+# Check the host, then run the managed demo (requires sudo for BlueZ access)
+sudo ./bzp-standalone doctor
+sudo ./bzp-standalone demo -d
 ```
 
 ### Build Options
@@ -166,7 +167,9 @@ update
    cd build
    cmake .. -DCMAKE_BUILD_TYPE=Debug
    make -j$(nproc)
-   sudo ./bzp-standalone -d  # Manual testing
+   sudo ./bzp-standalone doctor
+   sudo ./bzp-standalone demo -d
+   sudo ./bzp-standalone inspect --live  # Optional second terminal
    ```
 
 4. **Commit your changes** with clear messages
@@ -199,7 +202,7 @@ Please include:
 - **Steps to reproduce**: Minimal steps to trigger the issue
 - **Expected behavior**: What should happen
 - **Actual behavior**: What actually happens
-- **Logs**: Debug output with `-d` flag if applicable
+- **Logs**: `doctor`, `demo -d`, or `inspect --live --verbose-events` output if applicable
 
 ### Feature Requests
 

--- a/README-PACKAGING.md
+++ b/README-PACKAGING.md
@@ -216,7 +216,7 @@ bzp-standalone --help
 pkg-config --cflags --libs bzperi
 
 # Check D-Bus policy file
-ls /etc/dbus-1/system.d/com.bzperi.conf
+ls /usr/share/dbus-1/system.d/com.bzperi.conf
 
 # Check BlueZ configuration helper script
 ls /usr/share/bzperi/configure-bluez-experimental.sh
@@ -245,14 +245,17 @@ target_include_directories(your_app PRIVATE ${BZPERI_INCLUDE_DIRS})
 ### 5. Tools Usage
 
 ```bash
-# Check available BlueZ adapters
-sudo bzp-standalone --list-adapters
+# Check host readiness and available adapters
+sudo bzp-standalone doctor --list-adapters
 
-# Run demo server
-sudo bzp-standalone -d
+# Run the managed demo server
+sudo bzp-standalone demo -d
+
+# Inspect the managed session from another terminal
+sudo bzp-standalone inspect --live
 
 # Use specific adapter
-sudo bzp-standalone --adapter=hci1 -d
+sudo bzp-standalone demo --adapter=hci1 -d
 ```
 
 ## 🌐 Official Repository Distribution
@@ -348,7 +351,7 @@ Generally, D-Bus policies are automatically applied, but if there are issues:
 
 ```bash
 # Check D-Bus policy file
-ls -la /etc/dbus-1/system.d/com.bzperi.conf
+ls -la /usr/share/dbus-1/system.d/com.bzperi.conf
 
 # Manual D-Bus reload (for troubleshooting, generally unnecessary)
 sudo systemctl reload dbus
@@ -356,8 +359,8 @@ sudo systemctl reload dbus
 # Or full restart (last resort)
 sudo systemctl restart dbus
 
-# Test permissions
-sudo bzp-standalone --list-adapters
+# Re-check permissions and adapters
+sudo bzp-standalone doctor --list-adapters
 ```
 
 ### Repository Issues

--- a/README.md
+++ b/README.md
@@ -31,15 +31,17 @@ sudo apt install bzperi bzperi-dev bzperi-tools
 export BZPERI_AUTO_EXPERIMENTAL=1
 sudo -E apt install --reinstall bzperi
 
-# Run example server
-sudo bzp-standalone -d
+# Check the host, start the managed demo, then inspect it from another terminal
+sudo bzp-standalone doctor
+sudo bzp-standalone demo -d
+sudo bzp-standalone inspect --live
 ```
 
 ### Build from Source
 ```bash
 # Clone and build
 git clone https://github.com/jy1655/BzPeri.git
-cd bzperi
+cd BzPeri
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 make -j$(nproc)
@@ -49,9 +51,13 @@ make -j$(nproc)
 sudo cp ../dbus/com.bzperi.conf /etc/dbus-1/system.d/
 sudo ../scripts/configure-bluez-experimental.sh enable
 
-# Run example server
-sudo ./bzp-standalone -d
+# Check the host, start the managed demo, then inspect it from another terminal
+sudo ./bzp-standalone doctor
+sudo ./bzp-standalone demo -d
+sudo ./bzp-standalone inspect --live
 ```
+
+For a full first-run workflow, including Raspberry Pi / Debian-over-SSH notes and a verification-client path, see [STANDALONE_USAGE.md](STANDALONE_USAGE.md).
 
 ## What is BzPeri?
 
@@ -171,11 +177,14 @@ int main() {
 ### For Developers & Contributors
 - **[Build Guide](BUILD.md)** - Detailed build instructions, dependencies, and CMake options
 - **[Contributing Guide](CONTRIBUTING.md)** - Contribution workflow and repository expectations
+- **[Code of Conduct](CODE_OF_CONDUCT.md)** - Community expectations for contributors
+- **[Security Policy](SECURITY.md)** - Responsible disclosure and supported security reporting path
 
 ### Technical Documentation
 - **[Packaging Guide](README-PACKAGING.md)** - Debian package building and APT repository setup
 - **[BlueZ Migration](BLUEZ_MIGRATION.md)** - HCI Management API → D-Bus migration details
 - **[Modernization Guide](MODERNIZATION.md)** - 2019→2025 upgrade overview and architecture changes
+- **[Project TODOs](TODOS.md)** - Deferred follow-up work beyond the current release slice
 
 ## Header Layout
 
@@ -374,21 +383,20 @@ The included policy file (`dbus/com.bzperi.conf`) provides comprehensive permiss
 <busconfig>
   <!-- Root user permissions -->
   <policy user="root">
-    <allow own="com.bzperi"/>
-    <allow send_destination="com.bzperi"/>
+    <allow own_prefix="com.bzperi"/>
+    <allow send_destination_prefix="com.bzperi"/>
     <allow send_destination="org.bluez"/>
     <allow receive_sender="org.bluez"/>
   </policy>
 
   <!-- Bluetooth group permissions -->
   <policy group="bluetooth">
-    <allow send_destination="com.bzperi"/>
-    <allow receive_sender="com.bzperi"/>
+    <allow send_destination_prefix="com.bzperi"/>
   </policy>
 
   <!-- Introspection for debugging -->
   <policy context="default">
-    <allow send_destination="com.bzperi"
+    <allow send_destination_prefix="com.bzperi"
            send_interface="org.freedesktop.DBus.Introspectable"/>
   </policy>
 </busconfig>
@@ -398,6 +406,8 @@ The included policy file (`dbus/com.bzperi.conf`) provides comprehensive permiss
 
 **Check if policy is installed:**
 ```bash
+ls -la /usr/share/dbus-1/system.d/com.bzperi.conf
+# Or, for source-build/manual installs:
 ls -la /etc/dbus-1/system.d/com.bzperi.conf
 # Should show: -rw-r--r-- root root
 ```
@@ -417,7 +427,7 @@ sudo journalctl -u dbus -f
 
 Common issues:
 - **"Connection refused"**: D-Bus policy not installed or incorrect permissions
-- **"Access denied"**: Service name does not start with `bzperi.`
+- **"Access denied"**: Service name is not `bzperi` and does not start with `bzperi.`
 - **"Name already in use"**: Another instance is running
 
 **Force D-Bus to reload policies:**
@@ -503,12 +513,12 @@ if (!result) {
 ```
 
 ### Modern Adapter Management
-```cpp
-// List available adapters
-sudo ./bzp-standalone --list-adapters
+```bash
+# List available adapters
+sudo ./bzp-standalone doctor --list-adapters
 
-// Use specific adapter
-sudo ./bzp-standalone --adapter=hci1
+# Use a specific adapter for the managed demo
+sudo ./bzp-standalone demo --adapter=hci1
 ```
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -308,33 +308,89 @@ bzpStartWithBondable("bzperi.myapp", "name", "short", getter, setter, timeout, t
 
 ### Runtime Integration Modes
 
-BzPeri now supports two integration styles:
+BzPeri supports two integration styles. Pick the one that matches who owns the process lifecycle.
 
-- Thread-owned mode: `bzpStart*()` / `bzpStart*NoWait()` keep using the internal server thread.
-- Manual-iteration mode: `bzpStartManual()` / `bzpStartWithBondableManual()` create the dedicated GLib context without spawning the internal thread; the host then drives progress with `bzpRunLoopIteration()` or bounded waits via `bzpRunLoopIterationFor()`. The first iteration call becomes the owning thread for that manual run loop, or the host can claim/release ownership explicitly with `bzpRunLoopAttach()` / `bzpRunLoopDetach()`.
+| Mode | Main APIs | Best fit |
+|------|-----------|----------|
+| Thread-owned | `bzpStart*()` / `bzpStart*NoWait()` | Normal applications that are happy to let BzPeri run its own server thread |
+| Manual iteration | `bzpStartManual()` / `bzpStartWithBondableManual()` + `bzpRunLoopIteration*()` | Embedded hosts, existing event loops, or processes that want explicit control over startup, callbacks, and shutdown |
 
-Manual mode is the better fit when the host already owns its lifecycle and wants explicit control over when BLE initialization, D-Bus callbacks, and shutdown cleanup are pumped.
-For host-to-server scheduling without exposing GLib types directly, `bzpRunLoopInvoke()` can queue a callback onto the same dedicated run loop.
-For host event loops that already use `poll(2)`/`select(2)`-style integration, the hidden poll API `bzpRunLoopPollPrepare()` / `bzpRunLoopPollQuery()` / `bzpRunLoopPollCheck()` / `bzpRunLoopPollDispatch()` / `bzpRunLoopPollCancel()` exposes the dedicated run loop as plain poll descriptors instead of `GMainContext *`.
-For lifecycle control in manual mode, `bzpRunLoopDriveUntilState()` and `bzpRunLoopDriveUntilShutdown()` can pump the loop until a target state is reached.
-If the host needs to reason about ownership explicitly, `bzpRunLoopIsManualMode()`, `bzpRunLoopHasOwner()`, and `bzpRunLoopIsCurrentThreadOwner()` expose the current manual run-loop state.
-If the host needs failure-aware queries instead of legacy `0/1` predicates, `bzpRunLoopIsManualModeEx()`, `bzpRunLoopHasOwnerEx()`, `bzpRunLoopIsCurrentThreadOwnerEx()`, `bzpGetGLibLogCaptureEnabledEx()`, `bzpIsGLibLogCaptureInstalledEx()`, `bzpUpdateQueueIsEmptyEx()`, `bzpUpdateQueueSizeEx()`, and `bzpIsServerRunningEx()` return `BZPQueryResult` and write their answers through output pointers.
-For embedded hosts that need tighter control over process-global GLib handlers, `bzpSetGLibLogCaptureMode()` can switch between automatic capture, fully disabled capture, `HOST_MANAGED` capture with explicit `bzpInstallGLibLogCapture()` / `bzpRestoreGLibLogCapture()`, and `STARTUP_AND_SHUTDOWN` capture that automatically releases the process-global override once the server reaches `ERunning`. Mode changes are now applied against the current runtime state immediately, so switching from `DISABLED` to `AUTOMATIC` while the server is already active installs capture right away, and switching back to `DISABLED` or `HOST_MANAGED` fully restores any automatic capture depth. Hosts can also temporarily yield automatic capture without changing the configured mode by using `bzpPauseGLibLogCapture()` / `bzpResumeGLibLogCapture()`. The capture scope can also be narrowed with `bzpSetGLibLogCaptureTargets()` so hosts can intercept just `g_log` traffic or include `g_print` / `g_printerr` explicitly, and `bzpSetGLibLogCaptureDomains()` can further limit `g_log` interception to the default domain, `GLib`, `GIO`, BlueZ, or other application domains. `bzpGetConfiguredGLibLogCaptureDomains()` exposes the compiled-in default domain mask alongside the existing mode/target getters. If an external component replaces one of those process-global handlers while BzPeri capture is active, BzPeri now preserves that external handler during restore instead of blindly overwriting it; hosts can inspect and clear the sticky contention mask with `bzpGetGLibLogCaptureContentionTargetsEx()` / `bzpClearGLibLogCaptureContention()`. If the host needs failure reasons instead of `0/1`, `bzpSetGLibLogCaptureModeEx()` distinguishes invalid modes, `bzpSetGLibLogCaptureTargetsEx()` distinguishes invalid target masks, `bzpSetGLibLogCaptureDomainsEx()` distinguishes invalid domain masks, `bzpPauseGLibLogCaptureEx()` / `bzpResumeGLibLogCaptureEx()` distinguish wrong-mode vs not-paused cases, and `bzpInstallGLibLogCaptureEx()` / `bzpRestoreGLibLogCaptureEx()` distinguish `WRONG_MODE` and `NOT_INSTALLED`.
-On systemd-based systems, BzPeri can subscribe to `org.freedesktop.login1.Manager.PrepareForSleep` so active advertising is paused before suspend and restored after resume. Hosts can toggle this at runtime with `bzpSetPrepareForSleepIntegrationEnabled()` / `bzpGetPrepareForSleepIntegrationEnabledEx()`. Optional login1 `Inhibit("sleep", ..., "delay")` integration can also be enabled with `bzpSetSleepInhibitorEnabled()` / `bzpGetSleepInhibitorEnabledEx()` so the process keeps a delay inhibitor fd open while the server is active, releases it when suspend is actually beginning, and reacquires it after resume. When the inhibitor is enabled, BzPeri keeps the `PrepareForSleep` subscription active even if BLE advertising pause/resume integration itself is disabled, because the inhibitor lifecycle depends on that signal.
-The same detailed-result pattern is now available for wait helpers via `bzpWaitEx()` / `bzpWaitForStateEx()` / `bzpWaitForShutdownEx()` / `bzpShutdownAndWaitEx()`, which distinguish pre-start `NOT_RUNNING`, invalid state/timeout, timeouts, and join failures. Shutdown triggering now also has `bzpTriggerShutdownEx()`, which distinguishes `NOT_RUNNING` from repeated `ALREADY_STOPPING` requests.
-Update queue maintenance also has a detailed helper now: `bzpUpdateQueueClearEx()` reports how many queued entries were cleared instead of silently dropping them through the legacy `void` wrapper.
-At this point the remaining `0/1` and `void` forms are retained primarily as compatibility shims; new integration code should prefer the corresponding `Ex` and query-result APIs when failure reasons matter.
-Manual run-loop helpers follow the same pattern: `bzpRunLoopIterationEx()`, `bzpRunLoopAttachEx()`, `bzpRunLoopPollPrepareEx()`, `bzpRunLoopDriveUntilStateEx()` and related APIs distinguish `NOT_MANUAL_MODE`, `WRONG_THREAD`, `NO_POLL_CYCLE`, `BUFFER_TOO_SMALL`, and timeout/idle outcomes without exposing raw GLib types.
-The build-time defaults can be changed with `-DBZP_DEFAULT_GLIB_LOG_CAPTURE_MODE=AUTOMATIC|DISABLED|HOST_MANAGED|STARTUP_AND_SHUTDOWN`, `-DBZP_DEFAULT_GLIB_LOG_CAPTURE_TARGETS=ALL|LOG|LOG,PRINTERR|...`, `-DBZP_DEFAULT_GLIB_LOG_CAPTURE_DOMAINS=ALL|BLUEZ|GLIB,GIO|...`, `-DBZP_DEFAULT_PREPARE_FOR_SLEEP_INTEGRATION=ON|OFF`, and `-DBZP_DEFAULT_SLEEP_INHIBITOR=ON|OFF`; `bzpGetConfiguredGLibLogCaptureMode()`, `bzpGetConfiguredGLibLogCaptureTargets()`, `bzpGetConfiguredGLibLogCaptureDomains()`, `bzpGetConfiguredPrepareForSleepIntegrationEnabled()`, and `bzpGetConfiguredSleepInhibitorEnabled()` expose those compiled-in defaults at runtime.
-Production-oriented builds can also compile out lower-severity log paths with `-DBZP_COMPILED_LOG_LEVEL=TRACE|DEBUG|INFO|STATUS|WARN|ERROR|FATAL|ALWAYS`; `bzpGetConfiguredCompiledLogLevel()` reports that compiled-in minimum level at runtime.
-Builders that do not need deprecated singleton/global compatibility can configure CMake with `-DENABLE_LEGACY_SINGLETON_COMPAT=OFF`.
-With `ENABLE_LEGACY_SINGLETON_COMPAT=OFF`, the deprecated singleton/global implementation units are omitted from the build entirely. New C++ code that wants to avoid compatibility mirrors entirely can consult `getRuntimeServer()` / `getRuntimeServerPtr()` and `getRuntimeBluezAdapterPtr()` to see only the runtime-owned instances created by BzPeri itself.
-Builders that do not need deprecated raw GLib callback/method APIs can configure CMake with `-DENABLE_LEGACY_RAW_GLIB_COMPAT=OFF`.
-The same `ENABLE_LEGACY_RAW_GLIB_COMPAT=OFF` setting now also removes deprecated raw property getter/setter registration helpers, raw signal/reply/notification helpers, raw `GVariant*` property convenience overloads, raw `Utils::gvariantFrom*()` helpers, and their legacy alias names, so wrapper request-object paths become the only public extension surface.
-If the host needs detailed startup failure reasons instead of the legacy `0/1` return, use `bzpStartEx()` / `bzpStartWithBondableEx()` / `bzpStartManualEx()` and inspect `BZPStartResult`.
-The bundled `bzp-standalone` sample can be launched in this mode with `--manual-loop`, and its GLib capture strategy can be exercised with `--glib-log-capture=auto|off|host|startup-shutdown`, `--glib-log-targets=all|log|log,printerr`, and `--glib-log-domains=all|bluez|glib,gio`.
-When advertising starts, BzPeri now logs the selected payload mode (`legacy` vs `extended`), `MaxAdvLen`, and the UUIDs actually placed into the advertisement so Extended Advertising verification is visible at `INFO` level.
-Extended Advertising support is implemented in the payload selection path, but validation on an actually extended-capable controller is still pending because suitable test hardware was not available during this cycle.
+#### Manual Mode Tools
+
+Use manual mode when the host wants to decide exactly when BLE initialization, D-Bus callbacks, and cleanup are pumped.
+
+- `bzpRunLoopIteration()` / `bzpRunLoopIterationFor()`: drive progress directly
+- `bzpRunLoopAttach()` / `bzpRunLoopDetach()`: explicitly claim or release run-loop ownership
+- `bzpRunLoopInvoke()`: queue host work onto the same dedicated run loop
+- `bzpRunLoopDriveUntilState()` / `bzpRunLoopDriveUntilShutdown()`: pump until a lifecycle milestone is reached
+- `bzpRunLoopPollPrepare()` / `bzpRunLoopPollQuery()` / `bzpRunLoopPollCheck()` / `bzpRunLoopPollDispatch()` / `bzpRunLoopPollCancel()`: expose the run loop as plain poll descriptors for hosts that already use `poll(2)` or `select(2)`
+- `bzpRunLoopIsManualMode()`, `bzpRunLoopHasOwner()`, and `bzpRunLoopIsCurrentThreadOwner()`: inspect current ownership state
+
+If you want failure-aware results instead of legacy `0/1` behavior, use the `Ex` variants such as `bzpRunLoopIterationEx()`, `bzpRunLoopAttachEx()`, `bzpRunLoopPollPrepareEx()`, and `bzpRunLoopDriveUntilStateEx()`. These distinguish cases like `NOT_MANUAL_MODE`, `WRONG_THREAD`, `NO_POLL_CYCLE`, `BUFFER_TOO_SMALL`, and timeout or idle outcomes.
+
+#### GLib Log Capture
+
+For hosts that need tighter control over process-global GLib handlers, BzPeri exposes four capture modes through `bzpSetGLibLogCaptureMode()`:
+
+- `AUTOMATIC`: install capture while the runtime is active
+- `DISABLED`: never install capture automatically
+- `HOST_MANAGED`: the host explicitly calls `bzpInstallGLibLogCapture()` / `bzpRestoreGLibLogCapture()`
+- `STARTUP_AND_SHUTDOWN`: capture during lifecycle transitions, then release once the server reaches `ERunning`
+
+You can narrow the capture scope with:
+
+- `bzpSetGLibLogCaptureTargets()`: choose `g_log` only, or include `g_print` / `g_printerr`
+- `bzpSetGLibLogCaptureDomains()`: limit capture to default, `GLib`, `GIO`, BlueZ, or other application domains
+- `bzpPauseGLibLogCapture()` / `bzpResumeGLibLogCapture()`: temporarily yield capture without changing the configured mode
+
+Mode changes apply immediately against the current runtime state. If another component replaces one of the process-global handlers while capture is active, BzPeri preserves that external handler during restore instead of blindly overwriting it. Hosts can inspect and clear that contention state with `bzpGetGLibLogCaptureContentionTargetsEx()` / `bzpClearGLibLogCaptureContention()`.
+
+If you need structured failure reasons, prefer `bzpSetGLibLogCaptureModeEx()`, `bzpSetGLibLogCaptureTargetsEx()`, `bzpSetGLibLogCaptureDomainsEx()`, `bzpPauseGLibLogCaptureEx()`, `bzpResumeGLibLogCaptureEx()`, `bzpInstallGLibLogCaptureEx()`, and `bzpRestoreGLibLogCaptureEx()`.
+
+#### Power Management
+
+On systemd-based systems, BzPeri can subscribe to `org.freedesktop.login1.Manager.PrepareForSleep` so advertising pauses before suspend and resumes afterward.
+
+- `bzpSetPrepareForSleepIntegrationEnabled()` / `bzpGetPrepareForSleepIntegrationEnabledEx()`: toggle suspend/resume advertising integration
+- `bzpSetSleepInhibitorEnabled()` / `bzpGetSleepInhibitorEnabledEx()`: hold a login1 delay inhibitor fd while the server is active
+
+When the sleep inhibitor is enabled, BzPeri keeps the `PrepareForSleep` subscription active even if advertising pause/resume integration itself is disabled, because the inhibitor lifecycle depends on the same signal.
+
+#### Failure-Aware Control APIs
+
+The same detailed-result pattern now exists across the runtime control surface:
+
+- `bzpStartEx()` / `bzpStartWithBondableEx()` / `bzpStartManualEx()`: startup failure reasons via `BZPStartResult`
+- `bzpWaitEx()` / `bzpWaitForStateEx()` / `bzpWaitForShutdownEx()` / `bzpShutdownAndWaitEx()`: distinguish `NOT_RUNNING`, invalid state, timeout, and join failures
+- `bzpTriggerShutdownEx()`: distinguishes `NOT_RUNNING` from repeated `ALREADY_STOPPING`
+- `bzpUpdateQueueClearEx()`: reports how many queued entries were removed
+- `bzpRunLoopIsManualModeEx()`, `bzpRunLoopHasOwnerEx()`, `bzpRunLoopIsCurrentThreadOwnerEx()`, `bzpGetGLibLogCaptureEnabledEx()`, `bzpIsGLibLogCaptureInstalledEx()`, `bzpUpdateQueueIsEmptyEx()`, `bzpUpdateQueueSizeEx()`, and `bzpIsServerRunningEx()`: query APIs that return `BZPQueryResult` instead of plain `0/1`
+
+The older `0/1` and `void` forms still exist as compatibility shims, but new integration code should prefer the `Ex` and query-result variants when failure reasons matter.
+
+#### Build-Time Defaults
+
+You can change the compiled defaults with:
+
+- `-DBZP_DEFAULT_GLIB_LOG_CAPTURE_MODE=AUTOMATIC|DISABLED|HOST_MANAGED|STARTUP_AND_SHUTDOWN`
+- `-DBZP_DEFAULT_GLIB_LOG_CAPTURE_TARGETS=ALL|LOG|LOG,PRINTERR|...`
+- `-DBZP_DEFAULT_GLIB_LOG_CAPTURE_DOMAINS=ALL|BLUEZ|GLIB,GIO|...`
+- `-DBZP_DEFAULT_PREPARE_FOR_SLEEP_INTEGRATION=ON|OFF`
+- `-DBZP_DEFAULT_SLEEP_INHIBITOR=ON|OFF`
+- `-DBZP_COMPILED_LOG_LEVEL=TRACE|DEBUG|INFO|STATUS|WARN|ERROR|FATAL|ALWAYS`
+
+At runtime, the compiled defaults are visible through `bzpGetConfiguredGLibLogCaptureMode()`, `bzpGetConfiguredGLibLogCaptureTargets()`, `bzpGetConfiguredGLibLogCaptureDomains()`, `bzpGetConfiguredPrepareForSleepIntegrationEnabled()`, `bzpGetConfiguredSleepInhibitorEnabled()`, and `bzpGetConfiguredCompiledLogLevel()`.
+
+#### Compatibility Toggles
+
+If you do not need legacy compatibility layers, you can compile them out:
+
+- `-DENABLE_LEGACY_SINGLETON_COMPAT=OFF`: removes deprecated singleton/global implementation units, and new C++ code can rely on `getRuntimeServer()` / `getRuntimeServerPtr()` / `getRuntimeBluezAdapterPtr()`
+- `-DENABLE_LEGACY_RAW_GLIB_COMPAT=OFF`: removes deprecated raw property getter/setter registration helpers, raw signal/reply/notification helpers, raw `GVariant*` convenience overloads, raw `Utils::gvariantFrom*()` helpers, and their legacy alias names
+
+If you want to exercise these runtime options quickly, the bundled `bzp-standalone` sample supports `--manual-loop`, `--glib-log-capture=auto|off|host|startup-shutdown`, `--glib-log-targets=all|log|log,printerr`, and `--glib-log-domains=all|bluez|glib,gio`.
+
+When advertising starts, BzPeri now logs the selected payload mode (`legacy` vs `extended`), `MaxAdvLen`, and the UUIDs actually placed into the advertisement so extended-advertising verification is visible at `INFO` level. The payload path is implemented, but validation on actually extended-capable hardware is still pending.
 
 ## Configuration
 
@@ -359,11 +415,13 @@ sudo chmod 644 /etc/dbus-1/system.d/com.bzperi.conf
 sudo systemctl reload dbus
 ```
 
-**Alternative method** - Install via CMake:
+**Alternative method** - Install the runtime assets via CMake:
 ```bash
 cd build
-sudo cmake --install . --component dbus-policy
+sudo cmake --install . --component libraries
 ```
+
+This installs the runtime library, `bzp-standalone`, the D-Bus policy file, and the BlueZ helper script.
 
 #### Service Name Requirements
 

--- a/STANDALONE_USAGE.md
+++ b/STANDALONE_USAGE.md
@@ -2,25 +2,75 @@
 
 ## Overview
 
-`bzp-standalone` is the main sample application for validating a BzPeri build. In the `v0.2.x` line it covers not only adapter selection, but also manual run-loop mode, GLib capture controls, and sleep/power integration toggles.
+`bzp-standalone` is the main sample application for validating a BzPeri build. In the `v0.2.x` line it now acts as a small terminal-first control plane:
+
+- `bzp-standalone doctor` checks whether the host is ready for the happy path
+- `bzp-standalone demo` starts the managed sample BLE server
+- `bzp-standalone inspect --live` reads the managed demo session state without scraping stdout
+
+For backward compatibility, calling `bzp-standalone` with the old flat flags still enters the demo path.
+
+The intended first run is a 3-command workflow:
+
+```bash
+sudo ./build/bzp-standalone doctor
+sudo ./build/bzp-standalone demo -d
+sudo ./build/bzp-standalone inspect --live
+```
+
+`doctor` explains whether the box is sane. `demo` proves that the bundled sample really publishes. `inspect --live` shows the selected object, recent live events, and how to reveal the full object tree or verbose events when needed.
+
+## Workflow Paths
+
+### Ubuntu APT Install
+```bash
+sudo apt install bzperi bzperi-dev bzperi-tools
+sudo bzp-standalone doctor
+sudo bzp-standalone demo -d
+sudo bzp-standalone inspect --live
+```
+
+### Source Build
+```bash
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake --build . --parallel $(nproc)
+
+# Required before the first managed demo on a fresh host
+sudo cp ../dbus/com.bzperi.conf /etc/dbus-1/system.d/
+sudo ../scripts/configure-bluez-experimental.sh enable
+
+sudo ./bzp-standalone doctor
+sudo ./bzp-standalone demo -d
+sudo ./bzp-standalone inspect --live
+```
+
+### Raspberry Pi OS / Debian 12 over SSH
+```bash
+# Terminal 1: build or install, then check the host
+sudo ./build/bzp-standalone doctor
+
+# Terminal 1: start the managed sample
+sudo ./build/bzp-standalone demo -d
+
+# Terminal 2 over SSH: inspect the live session
+sudo ./build/bzp-standalone inspect --live
+```
+
+Use a phone app or second Linux machine as the verification client. The default sample exposes a battery characteristic at the reported `probe path` and a write-capable text characteristic at the reported `write probe` path, so a successful first run is: advertising is visible, the battery value can be read, the text value can be written, and `inspect --live` shows the object metadata plus read/write/notify activity.
 
 ## Command Line Options
-
-### Basic Usage
-```bash
-sudo ./build/bzp-standalone [options]
-```
 
 ### Logging Options
 ```bash
 # Quiet mode (errors only)
-sudo ./build/bzp-standalone -q
+sudo ./build/bzp-standalone demo -q
 
 # Verbose mode
-sudo ./build/bzp-standalone -v
+sudo ./build/bzp-standalone demo -v
 
 # Debug mode (most detailed)
-sudo ./build/bzp-standalone -d
+sudo ./build/bzp-standalone demo -d
 ```
 
 ### BlueZ Adapter Options
@@ -28,69 +78,75 @@ sudo ./build/bzp-standalone -d
 #### List Available Adapters
 ```bash
 # List all available BlueZ adapters
-sudo ./build/bzp-standalone --list-adapters
+sudo ./build/bzp-standalone doctor --list-adapters
 
 # Example output:
-#   Available BlueZ adapters:
-#     /org/bluez/hci0 (00:1A:2B:3C:4D:5E) - Powered: true
-#     /org/bluez/hci1 (AA:BB:CC:DD:EE:FF) - Powered: false
+#   ADAPTERS
+#   /org/bluez/hci0 [00:1A:2B:3C:4D:5E] powered=yes
+#   /org/bluez/hci1 [AA:BB:CC:DD:EE:FF] powered=no
 ```
 
 #### Select Specific Adapter
 ```bash
 # Use specific adapter by name
-sudo ./build/bzp-standalone --adapter=hci1
+sudo ./build/bzp-standalone doctor --adapter=hci1
+sudo ./build/bzp-standalone demo --adapter=hci1
 
 # Use specific adapter by path
-sudo ./build/bzp-standalone --adapter=/org/bluez/hci1
+sudo ./build/bzp-standalone doctor --adapter=/org/bluez/hci1
+sudo ./build/bzp-standalone demo --adapter=/org/bluez/hci1
 
 # Use specific adapter by MAC address
-sudo ./build/bzp-standalone --adapter=00:1A:2B:3C:4D:5E
+sudo ./build/bzp-standalone doctor --adapter=00:1A:2B:3C:4D:5E
+sudo ./build/bzp-standalone demo --adapter=00:1A:2B:3C:4D:5E
 ```
 
 #### Combined Options
 ```bash
-# Debug mode with specific adapter
-sudo ./build/bzp-standalone -d --adapter=hci1
+# Debug demo with a specific adapter
+sudo ./build/bzp-standalone demo -d --adapter=hci1
 
-# List adapters with verbose output
-sudo ./build/bzp-standalone -v --list-adapters
+# Show the object tree and low-signal events while inspecting
+sudo ./build/bzp-standalone inspect --live --show-tree --verbose-events
 ```
 
 ### Service Configuration Options
 ```bash
 # Override the D-Bus service namespace (updates characteristic paths)
-sudo ./build/bzp-standalone --service-name=my_device
+sudo ./build/bzp-standalone demo --service-name=my_device
 
 # Customize LE advertising names
-sudo ./build/bzp-standalone --advertise-name="My Device" --advertise-short=MyDev
+sudo ./build/bzp-standalone demo --advertise-name="My Device" --advertise-short=MyDev
 
 # Place bundled example services under a custom namespace node
-sudo ./build/bzp-standalone --service-name=my_device --sample-namespace=demo
+sudo ./build/bzp-standalone demo --service-name=my_device --sample-namespace=demo
 
 # Start with an empty server (no bundled example services)
-sudo ./build/bzp-standalone --no-sample-services
+sudo ./build/bzp-standalone demo --no-sample-services
 
 # Re-enable bundled services after disabling them in the same invocation
-sudo ./build/bzp-standalone --no-sample-services --with-sample-services
+sudo ./build/bzp-standalone demo --no-sample-services --with-sample-services
 
 # Run without the internal BzPeri worker thread
-sudo ./build/bzp-standalone --manual-loop
+sudo ./build/bzp-standalone demo --manual-loop
 
 # Control suspend/resume helpers
-sudo ./build/bzp-standalone --sleep-integration=off
-sudo ./build/bzp-standalone --sleep-inhibitor=on
+sudo ./build/bzp-standalone demo --sleep-integration=off
+sudo ./build/bzp-standalone demo --sleep-inhibitor=on
 
 # Control GLib capture strategy
-sudo ./build/bzp-standalone --glib-log-capture=host
-sudo ./build/bzp-standalone --glib-log-targets=log,printerr
-sudo ./build/bzp-standalone --glib-log-domains=bluez,gio
+sudo ./build/bzp-standalone demo --glib-log-capture=host
+sudo ./build/bzp-standalone demo --glib-log-targets=log,printerr
+sudo ./build/bzp-standalone demo --glib-log-domains=bluez,gio
 ```
 
 ### Help
 ```bash
 # Show help message
 ./build/bzp-standalone --help
+./build/bzp-standalone doctor --help
+./build/bzp-standalone demo --help
+./build/bzp-standalone inspect --help
 ```
 
 ## Environment Variables
@@ -100,11 +156,11 @@ You can also use environment variables instead of command-line options:
 ```bash
 # Set preferred adapter
 export BLUEZ_ADAPTER=hci1
-sudo ./build/bzp-standalone
+sudo ./build/bzp-standalone demo
 
 # Enable adapter listing
 export BLUEZ_LIST_ADAPTERS=1
-sudo ./build/bzp-standalone
+sudo ./build/bzp-standalone doctor
 ```
 
 ## Adapter Selection Logic
@@ -121,7 +177,7 @@ The application follows this priority order for adapter selection:
 ### Permission Issues
 ```bash
 # If you get permission errors:
-sudo ./build/bzp-standalone
+sudo ./build/bzp-standalone doctor
 
 # Or configure polkit rules (see BLUEZ_MIGRATION.md)
 ```
@@ -129,10 +185,10 @@ sudo ./build/bzp-standalone
 ### Adapter Not Found
 ```bash
 # List available adapters first
-sudo ./build/bzp-standalone --list-adapters
+sudo ./build/bzp-standalone doctor --list-adapters
 
 # Then use a valid adapter
-sudo ./build/bzp-standalone --adapter=hci0
+sudo ./build/bzp-standalone demo --adapter=hci0
 ```
 
 ### BlueZ Service Issues
@@ -144,7 +200,7 @@ systemctl status bluetooth
 sudo systemctl restart bluetooth
 
 # Then try again
-sudo ./build/bzp-standalone
+sudo ./build/bzp-standalone doctor
 ```
 
 ## Example Usage Scenarios
@@ -152,37 +208,37 @@ sudo ./build/bzp-standalone
 ### Development and Debugging
 ```bash
 # Start with debug logging and specific adapter
-sudo ./build/bzp-standalone -d --adapter=hci0
+sudo ./build/bzp-standalone demo -d --adapter=hci0
 ```
 
 ### Production Deployment
 ```bash
 # Quiet mode for production
-sudo ./build/bzp-standalone -q
+sudo ./build/bzp-standalone demo -q
 ```
 
 ### Multi-Adapter System
 ```bash
 # First, see what's available
-sudo ./build/bzp-standalone --list-adapters
+sudo ./build/bzp-standalone doctor --list-adapters
 
 # Select the best adapter
-sudo ./build/bzp-standalone --adapter=hci1
+sudo ./build/bzp-standalone demo --adapter=hci1
 ```
 
 ### Manual Run-Loop Validation
 ```bash
 # Run the sample in host-driven manual-loop mode
-sudo ./build/bzp-standalone -d --manual-loop
+sudo ./build/bzp-standalone demo -d --manual-loop
 ```
 
 ### GLib Capture Validation
 ```bash
 # Keep GLib capture fully host-managed
-sudo ./build/bzp-standalone -v --glib-log-capture=host
+sudo ./build/bzp-standalone demo -v --glib-log-capture=host
 
 # Use startup/shutdown-only capture with BlueZ/GIO domain filtering
-sudo ./build/bzp-standalone -v \
+sudo ./build/bzp-standalone demo -v \
   --glib-log-capture=startup-shutdown \
   --glib-log-domains=bluez,gio
 ```
@@ -190,7 +246,7 @@ sudo ./build/bzp-standalone -v \
 ### USB Bluetooth Dongle
 ```bash
 # When using USB Bluetooth dongles, they often appear as hci1 or higher
-sudo ./build/bzp-standalone --adapter=hci1
+sudo ./build/bzp-standalone demo --adapter=hci1
 ```
 
 ## Monitoring and Troubleshooting
@@ -242,7 +298,7 @@ Both signals will trigger a clean shutdown sequence that properly closes all Blu
 
 The application respects these configuration files:
 
-- **D-Bus Policy**: `/etc/dbus-1/system.d/com.bzperi.conf` (adjust prefix if you override `--service-name`)
+- **D-Bus Policy**: `/usr/share/dbus-1/system.d/com.bzperi.conf` for packaged installs, or `/etc/dbus-1/system.d/com.bzperi.conf` for source-build/manual installs
 - **Polkit Rules**: `/etc/polkit-1/rules.d/50-bzperi-bluez.rules`
 - **BlueZ Config**: `/etc/bluetooth/main.conf`
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,45 @@
+# TODOS
+
+## Inspector
+
+### Support Inspector Attach To External BzPeri Processes
+
+**What:** Let `inspect --live` attach to BzPeri processes outside the `bzp-standalone` managed demo path via an explicit registration and heartbeat contract.
+
+**Why:** The Phase 1 inspector is useful for the bundled workflow, but this is the step that turns it into a real product debugging tool for downstream apps.
+
+**Context:** This review intentionally reduced Phase 1 scope to BzPeri-managed sessions only. That keeps the first version honest and shippable, but it leaves a clear expansion point for real application processes. Start with a small registration channel, heartbeat, stale-session cleanup rule, and attach failure semantics instead of process discovery magic.
+
+**Effort:** M
+**Priority:** P2
+**Depends on:** Phase 1 inspector session contract and event aggregator stabilization
+
+## Distribution
+
+### Add Raspberry Pi APT Packaging For Workflow Tools
+
+**What:** Extend the existing package publishing flow so Raspberry Pi users can install the workflow-enabled `bzp-standalone` surface with `apt install`, not just from source.
+
+**Why:** The target environment is often an SSH session on Ubuntu or Raspberry Pi, so shipping only the source-build path leaves one of the most important real-world setups as a second-class experience.
+
+**Context:** This review kept Raspberry Pi APT distribution out of Phase 1 to preserve scope. The current repo already has Ubuntu-oriented APT publishing and arm builds in CI, so this is not starting from zero, but it still needs packaging verification for the new subcommand workflow and docs that treat Pi as a first-class install path.
+
+**Effort:** M
+**Priority:** P2
+**Depends on:** Phase 1 CLI contract and packaged workflow stabilization
+
+## Design
+
+### Promote Terminal Workflow Rules Into DESIGN.md Before Adding New Surfaces
+
+**What:** Create a repo-level `DESIGN.md` that captures the terminal workflow vocabulary, state language, status semantics, and next-step formatting before adding a TUI or browser mirror.
+
+**Why:** Phase 1 can live inside the approved plan, but the moment BzPeri grows a second presentation surface, the product language can drift unless the rules are centralized.
+
+**Context:** The design review intentionally kept Phase 1 lightweight by embedding terminal design rules directly in the plan instead of creating a full design system first. That is the right tradeoff now. It stops being enough once TUI layouts, browser mirrors, or richer exports exist. Start by lifting the stable parts of the Phase 1 contract: `PASS/WARN/FAIL` semantics, output framing, next-step line formatting, truncation disclosure, and tone guidelines.
+
+**Effort:** S
+**Priority:** P2
+**Depends on:** Phase 1 terminal workflow implementation and observed stable output patterns
+
+## Completed

--- a/dbus/com.bzperi.conf
+++ b/dbus/com.bzperi.conf
@@ -5,22 +5,21 @@
 
   <!-- Allow root to own the BzPeri service name -->
   <policy user="root">
-    <allow own="com.bzperi"/>
-    <allow send_destination="com.bzperi"/>
+    <allow own_prefix="com.bzperi"/>
+    <allow send_destination_prefix="com.bzperi"/>
     <allow send_destination="org.bluez"/>
     <allow receive_sender="org.bluez"/>
   </policy>
 
   <!-- Allow members of bluetooth group to access BzPeri service -->
   <policy group="bluetooth">
-    <allow send_destination="com.bzperi"/>
-    <allow receive_sender="com.bzperi"/>
+    <allow send_destination_prefix="com.bzperi"/>
   </policy>
 
   <!-- Allow any user to introspect the service (for debugging) -->
   <!-- Properties access remains available only to root/bluetooth via the policies above -->
   <policy context="default">
-    <allow send_destination="com.bzperi"
+    <allow send_destination_prefix="com.bzperi"
            send_interface="org.freedesktop.DBus.Introspectable"/>
   </policy>
 </busconfig>

--- a/samples/standalone.cpp
+++ b/samples/standalone.cpp
@@ -94,17 +94,29 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 #include <signal.h>
+#include <cerrno>
+#include <unistd.h>
+#include <gio/gio.h>
 #include <algorithm>
 #include <cctype>
+#include <filesystem>
 #include <iostream>
-#include <thread>
-#include <sstream>
-#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <optional>
 #include <vector>
+#include <cstdlib>
+#include <sstream>
+#include <thread>
 
 #include "../include/BzPeri.h"
 #include "../include/BzPeriConfigurator.h"
+#include "../include/bzp/BluezAdapter.h"
+#include "../include/bzp/DBusInterface.h"
+#include "../include/bzp/GattInterface.h"
+#include "../include/bzp/Server.h"
 #include "SampleServices.h"
+#include "../src/StandaloneWorkflow.h"
 
 //
 // Constants
@@ -326,9 +338,15 @@ static std::string serverDataTextString = "Hello, world!";
 
 // Cached D-Bus path for the sample battery characteristic
 static std::string batteryLevelObjectPath;
+static std::string textStringObjectPath;
 
 // Signal state is shared with the sample's main loop and must stay async-signal-safe.
 static volatile sig_atomic_t pendingShutdownSignal = 0;
+
+// Terminal-first inspect state is only active while a managed demo session is running.
+static std::unique_ptr<bzp::standalone::InspectSessionStore> inspectSessionStore;
+static std::unique_ptr<bzp::standalone::InspectSessionSnapshot> inspectSessionSnapshot;
+static std::recursive_mutex inspectSessionMutex;
 
 //
 // Logging
@@ -345,17 +363,17 @@ enum LogLevel
 // Our log level - defaulted to 'Normal' but can be modified via command-line options
 LogLevel logLevel = Normal;
 
-// Our full set of logging methods (we just log to stdout)
-//
-// NOTE: Some methods will only log if the appropriate `logLevel` is set
-void LogDebug(const char *pText) { if (logLevel <= Debug) { std::cout << "  DEBUG: " << pText << std::endl; } }
-void LogInfo(const char *pText) { if (logLevel <= Verbose) { std::cout << "   INFO: " << pText << std::endl; } }
-void LogStatus(const char *pText) { if (logLevel <= Normal) { std::cout << " STATUS: " << pText << std::endl; } }
-void LogWarn(const char *pText) { std::cout << "WARNING: " << pText << std::endl; }
-void LogError(const char *pText) { std::cout << "!!ERROR: " << pText << std::endl; }
-void LogFatal(const char *pText) { std::cout << "**FATAL: " << pText << std::endl; }
-void LogAlways(const char *pText) { std::cout << "..Log..: " << pText << std::endl; }
-void LogTrace(const char *pText) { std::cout << "-Trace-: " << pText << std::endl; }
+namespace {
+void LogDebug(const char *pText);
+void LogInfo(const char *pText);
+void LogStatus(const char *pText);
+void LogWarn(const char *pText);
+void LogError(const char *pText);
+void LogFatal(const char *pText);
+void LogAlways(const char *pText);
+void LogTrace(const char *pText);
+void recordInspectSemanticEvent(bzp::standalone::EventLevel level, const std::string &component, const std::string &message, bool refreshSnapshot = false);
+}
 
 //
 // Signal handling
@@ -398,10 +416,20 @@ const void *dataGetter(const char *pName)
 
 	if (strName == "battery/level")
 	{
+		recordInspectSemanticEvent(
+			bzp::standalone::EventLevel::Status,
+			"gatt",
+			std::string("read path=") + (batteryLevelObjectPath.empty() ? "/com/.../battery/level" : batteryLevelObjectPath)
+				+ " value=" + std::to_string(serverDataBatteryLevel) + "%");
 		return &serverDataBatteryLevel;
 	}
 	else if (strName == "text/string")
 	{
+		recordInspectSemanticEvent(
+			bzp::standalone::EventLevel::Status,
+			"gatt",
+			std::string("read path=") + (textStringObjectPath.empty() ? "/com/.../text/string" : textStringObjectPath)
+				+ " value='" + serverDataTextString + "'");
 		return serverDataTextString.c_str();
 	}
 
@@ -434,12 +462,24 @@ int dataSetter(const char *pName, const void *pData)
 	{
 		serverDataBatteryLevel = *static_cast<const uint8_t *>(pData);
 		LogDebug((std::string("Server data: battery level set to ") + std::to_string(serverDataBatteryLevel)).c_str());
+		recordInspectSemanticEvent(
+			bzp::standalone::EventLevel::Status,
+			"gatt",
+			std::string("write path=") + (batteryLevelObjectPath.empty() ? "/com/.../battery/level" : batteryLevelObjectPath)
+				+ " value=" + std::to_string(serverDataBatteryLevel) + "%",
+			true);
 		return 1;
 	}
 	else if (strName == "text/string")
 	{
 		serverDataTextString = static_cast<const char *>(pData);
 		LogDebug((std::string("Server data: text string set to '") + serverDataTextString + "'").c_str());
+		recordInspectSemanticEvent(
+			bzp::standalone::EventLevel::Status,
+			"gatt",
+			std::string("write path=") + (textStringObjectPath.empty() ? "/com/.../text/string" : textStringObjectPath)
+				+ " value='" + serverDataTextString + "'",
+			true);
 		return 1;
 	}
 
@@ -452,8 +492,29 @@ int dataSetter(const char *pName, const void *pData)
 // Entry point
 //
 
-int main(int argc, char **ppArgv)
+namespace {
+
+constexpr std::size_t kInspectEventLimit = 64;
+constexpr int kDefaultInspectRefreshMs = 500;
+
+enum class CommandMode
 {
+	TopLevelHelp,
+	Demo,
+	Doctor,
+	Inspect,
+};
+
+struct CommonOptions
+{
+	LogLevel requestedLogLevel = Normal;
+	std::string adapterName;
+	bool listAdapters = false;
+};
+
+struct DemoOptions
+{
+	CommonOptions common;
 	std::string serviceName = "bzperi";
 	std::string advertisingName = "BzPeri";
 	std::string advertisingShortName = "BzPeri";
@@ -466,257 +527,745 @@ int main(int argc, char **ppArgv)
 	bool sleepIntegrationEnabled = bzpGetConfiguredPrepareForSleepIntegrationEnabled() != 0;
 	bool sleepInhibitorEnabled = bzpGetConfiguredSleepInhibitorEnabled() != 0;
 	bool installHostManagedCapture = false;
+	bool showHelp = false;
+};
 
-	// A basic command-line parser
-	for (int i = 1; i < argc; ++i)
+struct DoctorOptions
+{
+	CommonOptions common;
+	bool showHelp = false;
+};
+
+struct InspectOptions
+{
+	bool live = false;
+	bool verboseEvents = false;
+	bool showTree = false;
+	int refreshMs = kDefaultInspectRefreshMs;
+	bool showHelp = false;
+};
+
+struct CommandSelection
+{
+	CommandMode mode = CommandMode::Demo;
+	std::size_t optionStartIndex = 1;
+};
+
+class RuntimeDoctorProbe final : public bzp::standalone::DoctorProbe
+{
+public:
+	bool checkSystemBus(std::string *detailOut) const override
 	{
-		std::string arg = ppArgv[i];
-		if (arg == "-q")
+		GError *error = nullptr;
+		GDBusConnection *connection = g_bus_get_sync(G_BUS_TYPE_SYSTEM, nullptr, &error);
+		if (connection == nullptr)
 		{
-			logLevel = ErrorsOnly;
-		}
-		else if (arg == "-v")
-		{
-			logLevel = Verbose;
-		}
-		else if  (arg == "-d")
-		{
-			logLevel = Debug;
-		}
-		else if (arg.substr(0, 10) == "--adapter=")
-		{
-			std::string adapterName = arg.substr(10);
-			// Set environment variable for BluezAdapter to use
-			setenv("BLUEZ_ADAPTER", adapterName.c_str(), 1);
-			LogStatus((std::string("Using BlueZ adapter: ") + adapterName).c_str());
-		}
-		else if (arg == "--list-adapters")
-		{
-			LogStatus("Available BlueZ adapters will be listed during startup");
-			setenv("BLUEZ_LIST_ADAPTERS", "1", 1);
-		}
-		else if (arg.rfind("--service-name=", 0) == 0)
-		{
-			serviceName = arg.substr(15);
-		}
-		else if (arg.rfind("--advertise-name=", 0) == 0)
-		{
-			advertisingName = arg.substr(17);
-		}
-		else if (arg.rfind("--advertise-short=", 0) == 0)
-		{
-			advertisingShortName = arg.substr(18);
-		}
-		else if (arg == "--no-sample-services")
-		{
-			includeSampleServices = false;
-		}
-		else if (arg == "--with-sample-services")
-		{
-			includeSampleServices = true;
-		}
-		else if (arg == "--manual-loop")
-		{
-			manualLoopMode = true;
-		}
-		else if (arg.rfind("--sleep-integration=", 0) == 0)
-		{
-			std::string mode = arg.substr(20);
-			std::transform(mode.begin(), mode.end(), mode.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-			if (mode == "on" || mode == "enable" || mode == "enabled" || mode == "true")
+			if (detailOut != nullptr)
 			{
-				sleepIntegrationEnabled = true;
+				*detailOut = error != nullptr ? error->message : "Failed to connect to the system bus.";
 			}
-			else if (mode == "off" || mode == "disable" || mode == "disabled" || mode == "false")
+			if (error != nullptr)
 			{
-				sleepIntegrationEnabled = false;
+				g_error_free(error);
+			}
+			return false;
+		}
+
+		if (detailOut != nullptr)
+		{
+			*detailOut = "Connected to the system D-Bus.";
+		}
+		g_object_unref(connection);
+		return true;
+	}
+
+	bool checkBluezService(std::string *detailOut) const override
+	{
+		GError *error = nullptr;
+		GDBusConnection *connection = g_bus_get_sync(G_BUS_TYPE_SYSTEM, nullptr, &error);
+		if (connection == nullptr)
+		{
+			if (detailOut != nullptr)
+			{
+				*detailOut = error != nullptr ? error->message : "Failed to connect to the system bus.";
+			}
+			if (error != nullptr)
+			{
+				g_error_free(error);
+			}
+			return false;
+		}
+
+		GVariant *reply = g_dbus_connection_call_sync(
+			connection,
+			"org.freedesktop.DBus",
+			"/org/freedesktop/DBus",
+			"org.freedesktop.DBus",
+			"NameHasOwner",
+			g_variant_new("(s)", "org.bluez"),
+			G_VARIANT_TYPE("(b)"),
+			G_DBUS_CALL_FLAGS_NONE,
+			3000,
+			nullptr,
+			&error);
+		g_object_unref(connection);
+
+		if (reply == nullptr)
+		{
+			if (detailOut != nullptr)
+			{
+				*detailOut = error != nullptr ? error->message : "Unable to query org.bluez ownership.";
+			}
+			if (error != nullptr)
+			{
+				g_error_free(error);
+			}
+			return false;
+		}
+
+		gboolean hasOwner = FALSE;
+		g_variant_get(reply, "(b)", &hasOwner);
+		g_variant_unref(reply);
+		if (detailOut != nullptr)
+		{
+			*detailOut = hasOwner != FALSE
+				? "org.bluez is present on the system bus."
+				: "org.bluez is not currently owned on the system bus.";
+		}
+		return hasOwner != FALSE;
+	}
+
+	bool checkServiceOwnership(const std::string &ownedName, std::string *detailOut) const override
+	{
+		GError *error = nullptr;
+		GDBusConnection *connection = g_bus_get_sync(G_BUS_TYPE_SYSTEM, nullptr, &error);
+		if (connection == nullptr)
+		{
+			if (detailOut != nullptr)
+			{
+				*detailOut = error != nullptr ? error->message : "Failed to connect to the system bus.";
+			}
+			if (error != nullptr)
+			{
+				g_error_free(error);
+			}
+			return false;
+		}
+
+		GVariant *reply = g_dbus_connection_call_sync(
+			connection,
+			"org.freedesktop.DBus",
+			"/org/freedesktop/DBus",
+			"org.freedesktop.DBus",
+			"RequestName",
+			g_variant_new("(su)", ownedName.c_str(), 4U),
+			G_VARIANT_TYPE("(u)"),
+			G_DBUS_CALL_FLAGS_NONE,
+			3000,
+			nullptr,
+			&error);
+		if (reply == nullptr)
+		{
+			if (detailOut != nullptr)
+			{
+				const bool looksLikePermissionIssue = error != nullptr
+					&& (std::string(error->message).find("AccessDenied") != std::string::npos
+						|| std::string(error->message).find("not allowed") != std::string::npos
+						|| std::string(error->message).find("denied") != std::string::npos);
+				if (looksLikePermissionIssue)
+				{
+					*detailOut = "Current user cannot own " + ownedName + " on the system bus. Re-run with sudo or install a custom D-Bus policy.";
+				}
+				else
+				{
+					*detailOut = error != nullptr ? error->message : ("Failed to request ownership for " + ownedName + ".");
+				}
+			}
+			if (error != nullptr)
+			{
+				g_error_free(error);
+			}
+			g_object_unref(connection);
+			return false;
+		}
+
+		guint resultCode = 0;
+		g_variant_get(reply, "(u)", &resultCode);
+		g_variant_unref(reply);
+
+		if (resultCode == 1U || resultCode == 4U)
+		{
+			GVariant *releaseReply = g_dbus_connection_call_sync(
+				connection,
+				"org.freedesktop.DBus",
+				"/org/freedesktop/DBus",
+				"org.freedesktop.DBus",
+				"ReleaseName",
+				g_variant_new("(s)", ownedName.c_str()),
+				G_VARIANT_TYPE("(u)"),
+				G_DBUS_CALL_FLAGS_NONE,
+				3000,
+				nullptr,
+				nullptr);
+			if (releaseReply != nullptr)
+			{
+				g_variant_unref(releaseReply);
+			}
+			g_object_unref(connection);
+			if (detailOut != nullptr)
+			{
+				*detailOut = "Current process can own " + ownedName + " on the system bus.";
+			}
+			return true;
+		}
+
+		g_object_unref(connection);
+		if (detailOut != nullptr)
+		{
+			if (resultCode == 3U)
+			{
+				*detailOut = ownedName + " is already owned by another process.";
 			}
 			else
 			{
-				LogFatal((std::string("Unknown sleep integration mode: '") + mode + "'").c_str());
-				LogFatal("Expected one of: on, off");
-				return -1;
+				*detailOut = "RequestName for " + ownedName + " returned unexpected result code " + std::to_string(resultCode) + ".";
 			}
 		}
-		else if (arg.rfind("--sleep-inhibitor=", 0) == 0)
+		return false;
+	}
+
+	bool probeAdapter(const std::string &preferredAdapter,
+		bool *poweredAdapterAvailableOut,
+		std::string *summaryOut,
+		std::vector<std::string> *adapterLinesOut,
+		std::string *detailOut) const override
+	{
+		if (poweredAdapterAvailableOut != nullptr)
 		{
-			std::string mode = arg.substr(19);
-			std::transform(mode.begin(), mode.end(), mode.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-			if (mode == "on" || mode == "enable" || mode == "enabled" || mode == "true")
+			*poweredAdapterAvailableOut = false;
+		}
+
+		auto &adapter = bzp::getActiveBluezAdapter();
+		adapter.setServiceNameContext("bzperi");
+		const auto initializeResult = adapter.initialize(preferredAdapter);
+		if (!initializeResult.isSuccess())
+		{
+			if (detailOut != nullptr)
 			{
-				sleepInhibitorEnabled = true;
+				*detailOut = initializeResult.errorMessage().empty()
+					? bzp::bluezErrorToString(initializeResult.error())
+					: initializeResult.errorMessage();
 			}
-			else if (mode == "off" || mode == "disable" || mode == "disabled" || mode == "false")
+			adapter.shutdown();
+			return false;
+		}
+
+		const auto adaptersResult = adapter.discoverAdapters();
+		if (!adaptersResult.isSuccess())
+		{
+			if (detailOut != nullptr)
 			{
-				sleepInhibitorEnabled = false;
+				*detailOut = adaptersResult.errorMessage();
 			}
-			else
+			adapter.shutdown();
+			return false;
+		}
+
+		std::ostringstream summary;
+		bool first = true;
+		bool poweredAdapterAvailable = false;
+		for (const auto &adapterInfo : adaptersResult.value())
+		{
+			if (adapterLinesOut != nullptr)
 			{
-				LogFatal((std::string("Unknown sleep inhibitor mode: '") + mode + "'").c_str());
-				LogFatal("Expected one of: on, off");
-				return -1;
+				adapterLinesOut->push_back(
+					adapterInfo.path + " [" + adapterInfo.address + "] powered=" + (adapterInfo.powered ? "yes" : "no"));
+			}
+			if (!first)
+			{
+				summary << "; ";
+			}
+			first = false;
+			summary << adapterInfo.path << " powered=" << (adapterInfo.powered ? "yes" : "no");
+			poweredAdapterAvailable = poweredAdapterAvailable || adapterInfo.powered;
+		}
+
+		if (summaryOut != nullptr)
+		{
+			*summaryOut = summary.str();
+		}
+		if (poweredAdapterAvailableOut != nullptr)
+		{
+			*poweredAdapterAvailableOut = poweredAdapterAvailable;
+		}
+		if (detailOut != nullptr)
+		{
+			*detailOut = poweredAdapterAvailable
+				? summary.str()
+				: ("Adapters found but none are powered: " + summary.str());
+		}
+
+		adapter.shutdown();
+		return true;
+	}
+
+	bool checkPolicy(std::string *pathOut) const override
+	{
+		const std::vector<std::string> policyCandidates = {
+			"/usr/share/dbus-1/system.d/com.bzperi.conf",
+			"/etc/dbus-1/system.d/com.bzperi.conf",
+		};
+		for (const auto &candidate : policyCandidates)
+		{
+			if (std::filesystem::exists(candidate))
+			{
+				if (pathOut != nullptr)
+				{
+					*pathOut = candidate;
+				}
+				return true;
 			}
 		}
-		else if (arg.rfind("--glib-log-capture=", 0) == 0)
+
+		if (pathOut != nullptr)
 		{
-			std::string mode = arg.substr(19);
-			std::transform(mode.begin(), mode.end(), mode.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-			if (mode == "auto" || mode == "automatic")
+			*pathOut = "/usr/share/dbus-1/system.d/com.bzperi.conf";
+		}
+		return false;
+	}
+
+	bool checkExperimentalHelper(std::string *pathOut, bool *modeEnabledOut, std::string *detailOut) const override
+	{
+		const auto runningProcessHasExperimental = []() {
+			const int processCheck = std::system("ps -eo args= | grep '[b]luetoothd' | grep -q -- '--experimental'");
+			return processCheck == 0;
+		};
+
+		const std::vector<std::string> helperCandidates = {
+			"/usr/share/bzperi/configure-bluez-experimental.sh",
+			"scripts/configure-bluez-experimental.sh",
+		};
+		for (const auto &candidate : helperCandidates)
+		{
+			if (std::filesystem::exists(candidate))
 			{
-				glibCaptureMode = BZP_GLIB_LOG_CAPTURE_AUTOMATIC;
-			}
-			else if (mode == "off" || mode == "disabled" || mode == "disable")
-			{
-				glibCaptureMode = BZP_GLIB_LOG_CAPTURE_DISABLED;
-			}
-			else if (mode == "host" || mode == "host-managed")
-			{
-				glibCaptureMode = BZP_GLIB_LOG_CAPTURE_HOST_MANAGED;
-				installHostManagedCapture = true;
-			}
-			else if (mode == "startup-shutdown" || mode == "transient")
-			{
-				glibCaptureMode = BZP_GLIB_LOG_CAPTURE_STARTUP_AND_SHUTDOWN;
-			}
-			else
-			{
-				LogFatal((std::string("Unknown GLib log capture mode: '") + mode + "'").c_str());
-				LogFatal("Expected one of: auto, off, host, startup-shutdown");
-				return -1;
+				if (pathOut != nullptr)
+				{
+					*pathOut = candidate;
+				}
+				if (modeEnabledOut != nullptr)
+				{
+					*modeEnabledOut = false;
+				}
+
+				const std::string command = "bash " + candidate + " check >/dev/null 2>&1";
+				const int result = std::system(command.c_str());
+				const bool helperEnabled = result == 0;
+				const bool runningEnabled = !helperEnabled && runningProcessHasExperimental();
+				const bool enabled = helperEnabled || runningEnabled;
+				if (modeEnabledOut != nullptr)
+				{
+					*modeEnabledOut = enabled;
+				}
+				if (detailOut != nullptr)
+				{
+					if (helperEnabled)
+					{
+						*detailOut = "Experimental mode is enabled (" + candidate + " check succeeded).";
+					}
+					else if (runningEnabled)
+					{
+						*detailOut = "Experimental mode is enabled in the running bluetoothd process, even though " + candidate + " check failed.";
+					}
+					else
+					{
+						*detailOut = "Experimental mode is not enabled (" + candidate + " check failed).";
+					}
+				}
+				return true;
 			}
 		}
-		else if (arg.rfind("--glib-log-targets=", 0) == 0)
+
+		const bool runningEnabled = runningProcessHasExperimental();
+		if (modeEnabledOut != nullptr)
 		{
-			unsigned int parsedTargets = 0;
-			const std::string targetSpec = arg.substr(19);
-			if (!parseGLibCaptureTargets(targetSpec, &parsedTargets))
+			*modeEnabledOut = runningEnabled;
+		}
+		if (detailOut != nullptr)
+		{
+			*detailOut = runningEnabled
+				? "BlueZ experimental helper was not found, but the running bluetoothd process includes --experimental."
+				: "BlueZ experimental helper was not found in the installed or source-build locations.";
+		}
+		return runningEnabled;
+	}
+};
+
+std::string executableName(const char *argv0)
+{
+	const std::filesystem::path argvPath(argv0 != nullptr ? argv0 : "bzp-standalone");
+	return argvPath.filename().string();
+}
+
+std::string toLowerCopy(std::string value)
+{
+	std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+		return static_cast<char>(std::tolower(ch));
+	});
+	return value;
+}
+
+std::string stripStructuredPrefix(const std::string &message, std::string *componentOut)
+{
+	if (!message.empty() && message.front() == '[')
+	{
+		const auto closeBracket = message.find(']');
+		if (closeBracket != std::string::npos)
+		{
+			if (componentOut != nullptr)
 			{
-				LogFatal((std::string("Unknown GLib log capture targets: '") + targetSpec + "'").c_str());
-				LogFatal("Expected 'all' or a comma-separated subset of: log, print, printerr");
-				return -1;
+				*componentOut = message.substr(1, closeBracket - 1);
 			}
-			glibCaptureTargets = parsedTargets;
-		}
-		else if (arg.rfind("--glib-log-domains=", 0) == 0)
-		{
-			unsigned int parsedDomains = 0;
-			const std::string domainSpec = arg.substr(19);
-			if (!parseGLibCaptureDomains(domainSpec, &parsedDomains))
+			if (closeBracket + 2 <= message.size() && message[closeBracket + 1] == ' ')
 			{
-				LogFatal((std::string("Unknown GLib log capture domains: '") + domainSpec + "'").c_str());
-				LogFatal("Expected 'all' or a comma-separated subset of: default, glib, gio, bluez, other");
-				return -1;
+				return message.substr(closeBracket + 2);
 			}
-			glibCaptureDomains = parsedDomains;
-		}
-		else if (arg.rfind("--sample-namespace=", 0) == 0)
-		{
-			sampleNamespace = arg.substr(19);
-		}
-		else if (arg == "--help" || arg == "-h")
-		{
-			LogAlways("Usage: standalone [options]");
-			LogAlways("");
-			LogAlways("Logging options:");
-			LogAlways("  -q              Quiet mode (errors only)");
-			LogAlways("  -v              Verbose mode");
-			LogAlways("  -d              Debug mode");
-			LogAlways("");
-			LogAlways("BlueZ options:");
-			LogAlways("  --adapter=NAME  Use specific adapter (e.g. hci0, hci1)");
-			LogAlways("  --list-adapters List available adapters and exit");
-			LogAlways("");
-			LogAlways("General options:");
-			LogAlways("  --service-name=NAME      Set D-Bus service namespace (default bzperi)");
-			LogAlways("  --advertise-name=NAME    Set LE advertising name (default BzPeri)");
-			LogAlways("  --advertise-short=NAME   Set LE advertising short name (default BzPeri)");
-			LogAlways("  --sample-namespace=NODE  Namespace node for example services (default samples)");
-			LogAlways("  --manual-loop            Drive BzPeri via bzpRunLoopIteration() instead of the internal thread");
-			LogAlways("  --sleep-integration=MODE Enable or disable systemd PrepareForSleep integration: on or off");
-			LogAlways("  --sleep-inhibitor=MODE   Enable or disable systemd sleep inhibitor support: on or off");
-			LogAlways("  --glib-log-capture=MODE Set GLib capture mode: auto, off, host, or startup-shutdown");
-			LogAlways("  --glib-log-targets=SET  Set GLib capture targets: all or comma-separated log,print,printerr");
-			LogAlways("  --glib-log-domains=SET  Set GLib log domains: all or comma-separated default,glib,gio,bluez,other");
-			LogAlways("  --no-sample-services      Disable bundled example GATT services");
-			LogAlways("  --with-sample-services    Re-enable bundled example services after disabling");
-			LogAlways("  --help, -h                Show this help message");
-			return 0;
-		}
-		else
-		{
-			LogFatal((std::string("Unknown parameter: '") + arg + "'").c_str());
-			LogFatal("");
-			LogFatal("Usage: standalone [options]");
-			LogFatal("Use --help for detailed options");
-			return -1;
+			return message.substr(closeBracket + 1);
 		}
 	}
 
-	auto toLowerCopy = [](std::string value)
+	if (componentOut != nullptr)
 	{
-		std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-		return value;
-	};
+		componentOut->clear();
+	}
+	return message;
+}
 
-	serviceName = toLowerCopy(serviceName);
-	sampleNamespace = toLowerCopy(sampleNamespace);
-
-	if (serviceName.empty())
+void persistInspectSession()
+{
+	std::lock_guard<std::recursive_mutex> lock(inspectSessionMutex);
+	if (!inspectSessionStore || !inspectSessionSnapshot)
 	{
-		LogFatal("Service name cannot be empty");
-		return -1;
+		return;
 	}
 
-	// Validate service name follows com.bzperi.* namespace pattern
-	if (serviceName != "bzperi" && serviceName.find("bzperi.") != 0)
+	std::string error;
+	if (!inspectSessionStore->save(*inspectSessionSnapshot, &error))
 	{
-		LogFatal("Service name must be 'bzperi' or start with 'bzperi.' (e.g., 'bzperi.myapp')");
-		LogFatal("This ensures D-Bus policy compatibility and prevents conflicts");
-		return -1;
+		std::cerr << "WARNING: failed to persist inspect session: " << error << std::endl;
+	}
+}
+
+bool isProcessAlive(int pid) noexcept
+{
+	if (pid <= 0)
+	{
+		return false;
 	}
 
-	if (sampleNamespace.find('/') != std::string::npos)
+	if (kill(pid, 0) == 0)
 	{
-		LogFatal("Sample namespace must not contain '/' characters");
-		return -1;
+		return true;
 	}
 
-	if (bzp::serviceConfiguratorCount() > 0)
+	return errno == EPERM;
+}
+
+std::string formatVariantValue(GVariant *variant)
+{
+	if (variant == nullptr)
 	{
-		LogWarn("Existing service configurators cleared for standalone configuration");
+		return "<null>";
 	}
 
-	bzp::clearServiceConfigurators();
+	gchar *printed = g_variant_print(variant, TRUE);
+	std::string result = printed != nullptr ? printed : "<print-failed>";
+	g_free(printed);
+	return result;
+}
 
-	if (includeSampleServices)
+std::string joinInterfaceNames(const bzp::DBusObject::InterfaceList &interfaces)
+{
+	std::ostringstream stream;
+	bool first = true;
+	for (const auto &interface : interfaces)
 	{
-		bzp::samples::registerSampleServices(sampleNamespace);
-
-		// Convert dots in service name to slashes for valid D-Bus object path
-		// e.g., "bzperi.myapp" becomes "/com/bzperi/myapp"
-		std::string pathServiceName = serviceName;
-		std::replace(pathServiceName.begin(), pathServiceName.end(), '.', '/');
-		std::string pathBase = std::string("/com/") + pathServiceName;
-
-		if (!sampleNamespace.empty())
+		if (!first)
 		{
-			pathBase += "/" + sampleNamespace;
+			stream << ", ";
 		}
+		first = false;
+		stream << interface->getName();
+	}
+	return stream.str();
+}
 
-		batteryLevelObjectPath = pathBase + "/battery/level";
-		LogStatus((std::string("Bundled example services registered under ") + pathBase).c_str());
+int countObjectsRecursive(const bzp::DBusObject &object)
+{
+	int count = 1;
+	for (const auto &child : object.getChildren())
+	{
+		count += countObjectsRecursive(child);
+	}
+	return count;
+}
+
+void appendObjectTreeLines(const bzp::DBusObject &object, int depth, std::vector<std::string> *lines)
+{
+	if (lines == nullptr)
+	{
+		return;
+	}
+
+	std::ostringstream line;
+	line << std::string(static_cast<std::size_t>(depth) * 2U, ' ') << object.getPath().toString();
+	if (!object.getInterfaces().empty())
+	{
+		line << " [" << joinInterfaceNames(object.getInterfaces()) << "]";
+	}
+	lines->push_back(line.str());
+
+	for (const auto &child : object.getChildren())
+	{
+		appendObjectTreeLines(child, depth + 1, lines);
+	}
+}
+
+bool appendSelectedObjectLines(const bzp::DBusObject &object, const std::string &selectedPath, bzp::standalone::InspectSessionSnapshot *snapshot)
+{
+	if (snapshot == nullptr)
+	{
+		return false;
+	}
+
+	if (object.getPath().toString() == selectedPath)
+	{
+		snapshot->selectedObjectSummary = "selected path: " + selectedPath;
+		snapshot->selectedObjectLines.push_back("object path: " + selectedPath);
+		snapshot->selectedObjectLines.push_back("interfaces: " + joinInterfaceNames(object.getInterfaces()));
+
+		for (const auto &interface : object.getInterfaces())
+		{
+			snapshot->selectedObjectLines.push_back("interface: " + interface->getName());
+			if (const auto gattInterface = std::dynamic_pointer_cast<const bzp::GattInterface>(interface))
+			{
+				std::string flagsValue;
+				for (const auto &property : gattInterface->getProperties())
+				{
+					if (property.getName() == "UUID"
+						|| property.getName() == "Flags"
+						|| property.getName() == "Service"
+						|| property.getName() == "Characteristic")
+					{
+						const auto value = formatVariantValue(property.getValueRef().get());
+						snapshot->selectedObjectLines.push_back("  " + property.getName() + ": " + value);
+						if (property.getName() == "Flags")
+						{
+							flagsValue = value;
+						}
+					}
+				}
+				if (flagsValue.find("notify") != std::string::npos)
+				{
+					snapshot->selectedObjectLines.push_back("  NotifyPath: " + selectedPath);
+				}
+			}
+		}
+		return true;
+	}
+
+	for (const auto &child : object.getChildren())
+	{
+		if (appendSelectedObjectLines(child, selectedPath, snapshot))
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+std::optional<bzp::standalone::InspectSessionSnapshot> buildInspectSnapshot(const DemoOptions &options)
+{
+	const auto server = bzp::getActiveServer();
+	if (!server)
+	{
+		return std::nullopt;
+	}
+
+	bzp::standalone::InspectSessionSnapshot snapshot;
+	snapshot.pid = static_cast<int>(getpid());
+	snapshot.updatedAtMs = bzp::standalone::currentTimeMs();
+	snapshot.serviceName = server->getServiceName();
+	snapshot.advertisingName = server->getAdvertisingName();
+	snapshot.advertisingShortName = server->getAdvertisingShortName();
+	snapshot.sampleNamespace = options.sampleNamespace;
+	snapshot.includeSampleServices = options.includeSampleServices;
+	snapshot.manualLoopMode = options.manualLoopMode;
+	snapshot.runState = static_cast<int>(bzpGetServerRunState());
+	snapshot.health = static_cast<int>(bzpGetServerHealth());
+	snapshot.objectRoot = !server->getObjects().empty()
+		? server->getObjects().begin()->getPath().toString()
+		: server->getRootObject().getPath().toString();
+	snapshot.selectedObjectPath = batteryLevelObjectPath.empty() ? snapshot.objectRoot : batteryLevelObjectPath;
+	snapshot.writeProbePath = textStringObjectPath;
+
+	for (const auto &object : server->getObjects())
+	{
+		snapshot.objectCount += countObjectsRecursive(object);
+		appendObjectTreeLines(object, 0, &snapshot.objectTreeLines);
+	}
+
+	if (!appendSelectedObjectLines(server->getRootObject(), snapshot.selectedObjectPath, &snapshot))
+	{
+		snapshot.selectedObjectLines.push_back("No detailed object metadata captured for " + snapshot.selectedObjectPath);
+	}
+
+	if (!batteryLevelObjectPath.empty() && snapshot.selectedObjectPath == batteryLevelObjectPath)
+	{
+		snapshot.selectedObjectLines.push_back("sample value: " + std::to_string(serverDataBatteryLevel) + "%");
+	}
+
+	auto adapterInfo = bzp::getActiveBluezAdapter().getAdapterInfo();
+	if (adapterInfo.isSuccess())
+	{
+		snapshot.adapterPath = adapterInfo.value().path;
+		snapshot.adapterAddress = adapterInfo.value().address;
+		snapshot.adapterAlias = adapterInfo.value().alias;
+		snapshot.adapterPowered = adapterInfo.value().powered;
 	}
 	else
 	{
-		batteryLevelObjectPath.clear();
-		LogStatus("Bundled example services disabled; starting with empty server");
+		snapshot.warnings.push_back("Adapter metadata unavailable: " + adapterInfo.errorMessage());
 	}
 
-	// Setup our signal handlers
-	installSignalHandler(SIGINT);
-	installSignalHandler(SIGTERM);
+	snapshot.activeConnections = bzp::getActiveBluezAdapter().getActiveConnectionCount();
+	snapshot.advertisingEnabled = bzp::getActiveBluezAdapter().isAdvertising();
+	if (!snapshot.includeSampleServices)
+	{
+		snapshot.warnings.push_back("Bundled sample services are disabled; inspect output will mostly reflect the empty server root.");
+	}
 
-	// Register our loggers
+	return snapshot;
+}
+
+void refreshInspectSession(bool rebuildTree)
+{
+	std::lock_guard<std::recursive_mutex> lock(inspectSessionMutex);
+	if (!inspectSessionSnapshot)
+	{
+		return;
+	}
+
+	const auto rebuilt = buildInspectSnapshot(DemoOptions{
+		{},
+		inspectSessionSnapshot->serviceName,
+		inspectSessionSnapshot->advertisingName,
+		inspectSessionSnapshot->advertisingShortName,
+		inspectSessionSnapshot->sampleNamespace,
+		inspectSessionSnapshot->includeSampleServices,
+		inspectSessionSnapshot->manualLoopMode
+	});
+	if (!rebuilt)
+	{
+		return;
+	}
+
+	auto refreshed = *rebuilt;
+	if (!rebuildTree)
+	{
+		refreshed.objectTreeLines = inspectSessionSnapshot->objectTreeLines;
+	}
+	refreshed.events = inspectSessionSnapshot->events;
+	*inspectSessionSnapshot = std::move(refreshed);
+	persistInspectSession();
+}
+
+void clearInspectSession()
+{
+	std::lock_guard<std::recursive_mutex> lock(inspectSessionMutex);
+	if (inspectSessionStore)
+	{
+		std::string error;
+		if (!inspectSessionStore->clear(&error) && !error.empty())
+		{
+			std::cerr << "WARNING: failed to clear inspect session: " << error << std::endl;
+		}
+	}
+	inspectSessionSnapshot.reset();
+	inspectSessionStore.reset();
+}
+
+void recordSessionEvent(bzp::standalone::EventLevel level, const char *text)
+{
+	std::lock_guard<std::recursive_mutex> lock(inspectSessionMutex);
+	if (!inspectSessionStore || !inspectSessionSnapshot || text == nullptr)
+	{
+		return;
+	}
+
+	std::string component;
+	const std::string rawMessage(text);
+	const std::string message = stripStructuredPrefix(rawMessage, &component);
+	bzp::standalone::appendInspectEvent(*inspectSessionSnapshot, {
+		bzp::standalone::currentTimeMs(),
+		level,
+		component,
+		message,
+	}, inspectSessionStore->eventLimit());
+
+	if (message.find("op=Connection") != std::string::npos
+		|| message.find("op=Initialize") != std::string::npos
+		|| message.find("shutting down") != std::string::npos)
+	{
+		refreshInspectSession(false);
+		return;
+	}
+
+	persistInspectSession();
+}
+
+void recordInspectSemanticEvent(bzp::standalone::EventLevel level, const std::string &component, const std::string &message, bool refreshSnapshot)
+{
+	std::lock_guard<std::recursive_mutex> lock(inspectSessionMutex);
+	if (!inspectSessionStore || !inspectSessionSnapshot || message.empty())
+	{
+		return;
+	}
+
+	bzp::standalone::appendInspectEvent(*inspectSessionSnapshot, {
+		bzp::standalone::currentTimeMs(),
+		level,
+		component,
+		message,
+	}, inspectSessionStore->eventLimit());
+
+	if (refreshSnapshot)
+	{
+		refreshInspectSession(false);
+		return;
+	}
+
+	persistInspectSession();
+}
+
+void LogDebug(const char *pText) { recordSessionEvent(bzp::standalone::EventLevel::Debug, pText); if (logLevel <= Debug) { std::cout << "  DEBUG: " << pText << std::endl; } }
+void LogInfo(const char *pText) { recordSessionEvent(bzp::standalone::EventLevel::Info, pText); if (logLevel <= Verbose) { std::cout << "   INFO: " << pText << std::endl; } }
+void LogStatus(const char *pText) { recordSessionEvent(bzp::standalone::EventLevel::Status, pText); if (logLevel <= Normal) { std::cout << " STATUS: " << pText << std::endl; } }
+void LogWarn(const char *pText) { recordSessionEvent(bzp::standalone::EventLevel::Warn, pText); std::cout << "WARNING: " << pText << std::endl; }
+void LogError(const char *pText) { recordSessionEvent(bzp::standalone::EventLevel::Error, pText); std::cout << "!!ERROR: " << pText << std::endl; }
+void LogFatal(const char *pText) { recordSessionEvent(bzp::standalone::EventLevel::Fatal, pText); std::cout << "**FATAL: " << pText << std::endl; }
+void LogAlways(const char *pText) { recordSessionEvent(bzp::standalone::EventLevel::Status, pText); std::cout << "..Log..: " << pText << std::endl; }
+void LogTrace(const char *pText)
+{
+	recordSessionEvent(bzp::standalone::EventLevel::Trace, pText);
+	if (logLevel <= Debug)
+	{
+		std::cout << "-Trace-: " << pText << std::endl;
+	}
+}
+
+void registerLoggers()
+{
 	bzpLogRegisterDebug(LogDebug);
 	bzpLogRegisterInfo(LogInfo);
 	bzpLogRegisterStatus(LogStatus);
@@ -725,36 +1274,535 @@ int main(int argc, char **ppArgv)
 	bzpLogRegisterFatal(LogFatal);
 	bzpLogRegisterAlways(LogAlways);
 	bzpLogRegisterTrace(LogTrace);
+}
 
-	bzpSetPrepareForSleepIntegrationEnabled(sleepIntegrationEnabled ? 1 : 0);
-	bzpSetSleepInhibitorEnabled(sleepInhibitorEnabled ? 1 : 0);
-	bzpSetGLibLogCaptureMode(glibCaptureMode);
-	bzpSetGLibLogCaptureTargets(glibCaptureTargets);
-	bzpSetGLibLogCaptureDomains(glibCaptureDomains);
-	LogStatus((std::string("Compiled log level: ") + describeCompiledLogLevel(bzpGetConfiguredCompiledLogLevel())).c_str());
-	LogStatus((std::string("PrepareForSleep integration: ") + (sleepIntegrationEnabled ? "enabled" : "disabled")).c_str());
-	LogStatus((std::string("Sleep inhibitor integration: ") + (sleepInhibitorEnabled ? "enabled" : "disabled")).c_str());
-	if (glibCaptureMode == BZP_GLIB_LOG_CAPTURE_AUTOMATIC)
+void applyCommonOptions(const CommonOptions &common)
+{
+	logLevel = common.requestedLogLevel;
+
+	if (!common.adapterName.empty())
 	{
-		LogStatus("GLib log capture mode: automatic");
-	}
-	else if (glibCaptureMode == BZP_GLIB_LOG_CAPTURE_STARTUP_AND_SHUTDOWN)
-	{
-		LogStatus("GLib log capture mode: startup-and-shutdown");
-	}
-	else if (glibCaptureMode == BZP_GLIB_LOG_CAPTURE_DISABLED)
-	{
-		LogStatus("GLib log capture mode: disabled");
+		setenv("BLUEZ_ADAPTER", common.adapterName.c_str(), 1);
 	}
 	else
 	{
-		LogStatus("GLib log capture mode: host-managed");
+		unsetenv("BLUEZ_ADAPTER");
 	}
-	LogStatus((std::string("GLib log capture targets: ") + describeGLibCaptureTargets(glibCaptureTargets)).c_str());
-	LogStatus((std::string("GLib log capture domains: ") + describeGLibCaptureDomains(glibCaptureDomains)).c_str());
+
+	if (common.listAdapters)
+	{
+		setenv("BLUEZ_LIST_ADAPTERS", "1", 1);
+	}
+	else
+	{
+		unsetenv("BLUEZ_LIST_ADAPTERS");
+	}
+}
+
+std::string buildTopLevelHelp(const std::string &binaryName)
+{
+	std::ostringstream stream;
+	stream << "Usage: " << binaryName << " <command> [options]\n";
+	stream << "       " << binaryName << " [demo options]\n\n";
+	stream << "Commands:\n";
+	stream << "  doctor   Check the local host for the BzPeri happy path\n";
+	stream << "  demo     Start the managed sample server\n";
+	stream << "  inspect  Inspect a managed demo session (use --live)\n\n";
+	stream << "Examples:\n";
+	stream << "  " << binaryName << " doctor\n";
+	stream << "  " << binaryName << " demo -d --adapter=hci0\n";
+	stream << "  " << binaryName << " inspect --live\n\n";
+	stream << "Legacy compatibility:\n";
+	stream << "  " << binaryName << " --adapter=hci0 -d\n\n";
+	stream << "Run '" << binaryName << " <command> --help' for command-specific options.\n";
+	return stream.str();
+}
+
+std::string buildDemoHelp(const std::string &binaryName)
+{
+	std::ostringstream stream;
+	stream << "Usage: " << binaryName << " demo [options]\n";
+	stream << "       " << binaryName << " [options]\n\n";
+	stream << "Logging options:\n";
+	stream << "  -q                         Quiet mode (errors only)\n";
+	stream << "  -v                         Verbose mode\n";
+	stream << "  -d                         Debug mode\n\n";
+	stream << "BlueZ options:\n";
+	stream << "  --adapter=NAME             Use specific adapter (e.g. hci0)\n";
+	stream << "  --list-adapters            List available adapters during startup\n\n";
+	stream << "General options:\n";
+	stream << "  --service-name=NAME        Set D-Bus service namespace (default bzperi)\n";
+	stream << "  --advertise-name=NAME      Set LE advertising name (default BzPeri)\n";
+	stream << "  --advertise-short=NAME     Set LE advertising short name (default BzPeri)\n";
+	stream << "  --sample-namespace=NODE    Namespace node for example services (default samples)\n";
+	stream << "  --manual-loop              Drive BzPeri via bzpRunLoopIteration()\n";
+	stream << "  --sleep-integration=MODE   Enable or disable PrepareForSleep integration: on or off\n";
+	stream << "  --sleep-inhibitor=MODE     Enable or disable sleep inhibitor support: on or off\n";
+	stream << "  --glib-log-capture=MODE    Set GLib capture mode: auto, off, host, startup-shutdown\n";
+	stream << "  --glib-log-targets=SET     Set GLib capture targets: all or log,print,printerr\n";
+	stream << "  --glib-log-domains=SET     Set GLib capture domains: all or default,glib,gio,bluez,other\n";
+	stream << "  --no-sample-services       Disable bundled example GATT services\n";
+	stream << "  --with-sample-services     Re-enable bundled example services after disabling\n";
+	return stream.str();
+}
+
+std::string buildDoctorHelp(const std::string &binaryName)
+{
+	std::ostringstream stream;
+	stream << "Usage: " << binaryName << " doctor [options]\n\n";
+	stream << "Options:\n";
+	stream << "  -q                         Quiet mode (errors only)\n";
+	stream << "  -v                         Verbose mode\n";
+	stream << "  -d                         Debug mode\n";
+	stream << "  --adapter=NAME             Probe a specific adapter\n";
+	stream << "  --list-adapters            Include adapter listing during the probe\n";
+	return stream.str();
+}
+
+std::string buildInspectHelp(const std::string &binaryName)
+{
+	std::ostringstream stream;
+	stream << "Usage: " << binaryName << " inspect --live [options]\n\n";
+	stream << "Options:\n";
+	stream << "  --live                     Attach to the managed demo session and print updates\n";
+	stream << "  --verbose-events           Show debug/info chatter in the event block\n";
+	stream << "  --show-tree                Include the full object tree in the report\n";
+	stream << "  --refresh-ms=INT           Poll the session file for updates (default " << kDefaultInspectRefreshMs << "ms)\n";
+	return stream.str();
+}
+
+CommandSelection selectCommand(int argc, char **argv)
+{
+	if (argc <= 1)
+	{
+		return {CommandMode::Demo, 1};
+	}
+
+	const std::string firstArg = argv[1];
+	if (firstArg == "--help" || firstArg == "-h")
+	{
+		return {CommandMode::TopLevelHelp, 2};
+	}
+	if (firstArg == "demo")
+	{
+		return {CommandMode::Demo, 2};
+	}
+	if (firstArg == "doctor")
+	{
+		return {CommandMode::Doctor, 2};
+	}
+	if (firstArg == "inspect")
+	{
+		return {CommandMode::Inspect, 2};
+	}
+	if (!firstArg.empty() && firstArg[0] != '-')
+	{
+		return {CommandMode::TopLevelHelp, 0};
+	}
+	return {CommandMode::Demo, 1};
+}
+
+bool parseCommonOption(const std::string &arg, CommonOptions *common)
+{
+	if (common == nullptr)
+	{
+		return false;
+	}
+
+	if (arg == "-q")
+	{
+		common->requestedLogLevel = ErrorsOnly;
+		return true;
+	}
+	if (arg == "-v")
+	{
+		common->requestedLogLevel = Verbose;
+		return true;
+	}
+	if (arg == "-d")
+	{
+		common->requestedLogLevel = Debug;
+		return true;
+	}
+	if (arg.rfind("--adapter=", 0) == 0)
+	{
+		common->adapterName = arg.substr(10);
+		return true;
+	}
+	if (arg == "--list-adapters")
+	{
+		common->listAdapters = true;
+		return true;
+	}
+	return false;
+}
+
+bool parseDemoOptions(int argc, char **argv, std::size_t startIndex, DemoOptions *options, std::string *errorOut)
+{
+	for (std::size_t i = startIndex; i < static_cast<std::size_t>(argc); ++i)
+	{
+		const std::string arg = argv[i];
+		if (parseCommonOption(arg, &options->common))
+		{
+			continue;
+		}
+		if (arg.rfind("--service-name=", 0) == 0)
+		{
+			options->serviceName = arg.substr(15);
+		}
+		else if (arg.rfind("--advertise-name=", 0) == 0)
+		{
+			options->advertisingName = arg.substr(17);
+		}
+		else if (arg.rfind("--advertise-short=", 0) == 0)
+		{
+			options->advertisingShortName = arg.substr(18);
+		}
+		else if (arg == "--no-sample-services")
+		{
+			options->includeSampleServices = false;
+		}
+		else if (arg == "--with-sample-services")
+		{
+			options->includeSampleServices = true;
+		}
+		else if (arg == "--manual-loop")
+		{
+			options->manualLoopMode = true;
+		}
+		else if (arg.rfind("--sleep-integration=", 0) == 0)
+		{
+			std::string mode = toLowerCopy(arg.substr(20));
+			if (mode == "on" || mode == "enable" || mode == "enabled" || mode == "true")
+			{
+				options->sleepIntegrationEnabled = true;
+			}
+			else if (mode == "off" || mode == "disable" || mode == "disabled" || mode == "false")
+			{
+				options->sleepIntegrationEnabled = false;
+			}
+			else
+			{
+				*errorOut = "Unknown sleep integration mode: " + mode;
+				return false;
+			}
+		}
+		else if (arg.rfind("--sleep-inhibitor=", 0) == 0)
+		{
+			std::string mode = toLowerCopy(arg.substr(19));
+			if (mode == "on" || mode == "enable" || mode == "enabled" || mode == "true")
+			{
+				options->sleepInhibitorEnabled = true;
+			}
+			else if (mode == "off" || mode == "disable" || mode == "disabled" || mode == "false")
+			{
+				options->sleepInhibitorEnabled = false;
+			}
+			else
+			{
+				*errorOut = "Unknown sleep inhibitor mode: " + mode;
+				return false;
+			}
+		}
+		else if (arg.rfind("--glib-log-capture=", 0) == 0)
+		{
+			const std::string mode = toLowerCopy(arg.substr(19));
+			if (mode == "auto" || mode == "automatic")
+			{
+				options->glibCaptureMode = BZP_GLIB_LOG_CAPTURE_AUTOMATIC;
+			}
+			else if (mode == "off" || mode == "disabled" || mode == "disable")
+			{
+				options->glibCaptureMode = BZP_GLIB_LOG_CAPTURE_DISABLED;
+			}
+			else if (mode == "host" || mode == "host-managed")
+			{
+				options->glibCaptureMode = BZP_GLIB_LOG_CAPTURE_HOST_MANAGED;
+				options->installHostManagedCapture = true;
+			}
+			else if (mode == "startup-shutdown" || mode == "transient")
+			{
+				options->glibCaptureMode = BZP_GLIB_LOG_CAPTURE_STARTUP_AND_SHUTDOWN;
+			}
+			else
+			{
+				*errorOut = "Unknown GLib log capture mode: " + mode;
+				return false;
+			}
+		}
+		else if (arg.rfind("--glib-log-targets=", 0) == 0)
+		{
+			unsigned int parsedTargets = 0;
+			const std::string targetSpec = arg.substr(19);
+			if (!parseGLibCaptureTargets(targetSpec, &parsedTargets))
+			{
+				*errorOut = "Unknown GLib log capture targets: " + targetSpec;
+				return false;
+			}
+			options->glibCaptureTargets = parsedTargets;
+		}
+		else if (arg.rfind("--glib-log-domains=", 0) == 0)
+		{
+			unsigned int parsedDomains = 0;
+			const std::string domainSpec = arg.substr(19);
+			if (!parseGLibCaptureDomains(domainSpec, &parsedDomains))
+			{
+				*errorOut = "Unknown GLib log capture domains: " + domainSpec;
+				return false;
+			}
+			options->glibCaptureDomains = parsedDomains;
+		}
+		else if (arg.rfind("--sample-namespace=", 0) == 0)
+		{
+			options->sampleNamespace = arg.substr(19);
+		}
+		else if (arg == "--help" || arg == "-h")
+		{
+			options->showHelp = true;
+		}
+		else
+		{
+			*errorOut = "Unknown parameter: " + arg;
+			return false;
+		}
+	}
+	return true;
+}
+
+bool parseDoctorOptions(int argc, char **argv, std::size_t startIndex, DoctorOptions *options, std::string *errorOut)
+{
+	for (std::size_t i = startIndex; i < static_cast<std::size_t>(argc); ++i)
+	{
+		const std::string arg = argv[i];
+		if (parseCommonOption(arg, &options->common))
+		{
+			continue;
+		}
+		if (arg == "--help" || arg == "-h")
+		{
+			options->showHelp = true;
+			continue;
+		}
+		*errorOut = "Unknown parameter: " + arg;
+		return false;
+	}
+	return true;
+}
+
+bool parseInspectOptions(int argc, char **argv, std::size_t startIndex, InspectOptions *options, std::string *errorOut)
+{
+	for (std::size_t i = startIndex; i < static_cast<std::size_t>(argc); ++i)
+	{
+		const std::string arg = argv[i];
+		if (arg == "--help" || arg == "-h")
+		{
+			options->showHelp = true;
+		}
+		else if (arg == "--live")
+		{
+			options->live = true;
+		}
+		else if (arg == "--verbose-events")
+		{
+			options->verboseEvents = true;
+		}
+		else if (arg == "--show-tree")
+		{
+			options->showTree = true;
+		}
+		else if (arg.rfind("--refresh-ms=", 0) == 0)
+		{
+			options->refreshMs = std::max(100, std::atoi(arg.substr(13).c_str()));
+		}
+		else
+		{
+			*errorOut = "Unknown parameter: " + arg;
+			return false;
+		}
+	}
+
+	if (!options->showHelp && !options->live)
+	{
+		*errorOut = "inspect currently requires --live";
+		return false;
+	}
+	return true;
+}
+
+void printBlock(const std::string &text)
+{
+	std::cout << text;
+	if (!text.empty() && text.back() != '\n')
+	{
+		std::cout << '\n';
+	}
+}
+
+int validateDemoOptions(DemoOptions *options)
+{
+	options->serviceName = toLowerCopy(options->serviceName);
+	options->sampleNamespace = toLowerCopy(options->sampleNamespace);
+
+	if (options->serviceName.empty())
+	{
+		LogFatal("Service name cannot be empty");
+		return -1;
+	}
+	if (options->serviceName != "bzperi" && options->serviceName.find("bzperi.") != 0)
+	{
+		LogFatal("Service name must be 'bzperi' or start with 'bzperi.' (e.g., 'bzperi.myapp')");
+		LogFatal("This ensures D-Bus policy compatibility and prevents conflicts");
+		return -1;
+	}
+	if (options->sampleNamespace.find('/') != std::string::npos)
+	{
+		LogFatal("Sample namespace must not contain '/' characters");
+		return -1;
+	}
+	return 0;
+}
+
+void configureDemoServices(const DemoOptions &options)
+{
+	if (bzp::serviceConfiguratorCount() > 0)
+	{
+		LogWarn("Existing service configurators cleared for standalone configuration");
+	}
+
+	bzp::clearServiceConfigurators();
+
+	if (options.includeSampleServices)
+	{
+		bzp::samples::registerSampleServices(options.sampleNamespace);
+		std::string pathServiceName = options.serviceName;
+		std::replace(pathServiceName.begin(), pathServiceName.end(), '.', '/');
+		std::string pathBase = std::string("/com/") + pathServiceName;
+		if (!options.sampleNamespace.empty())
+		{
+			pathBase += "/" + options.sampleNamespace;
+		}
+		batteryLevelObjectPath = pathBase + "/battery/level";
+		textStringObjectPath = pathBase + "/text/string";
+		LogStatus((std::string("Bundled example services registered under ") + pathBase).c_str());
+	}
+	else
+	{
+		batteryLevelObjectPath.clear();
+		textStringObjectPath.clear();
+		LogStatus("Bundled example services disabled; starting with empty server");
+	}
+}
+
+bzp::standalone::DoctorSnapshot collectDoctorSnapshot(const DoctorOptions &options, const std::string &ownedName = "com.bzperi")
+{
+	RuntimeDoctorProbe probe;
+	auto snapshot = bzp::standalone::collectDoctorSnapshot(probe, options.common.adapterName, ownedName);
+	if (!options.common.listAdapters)
+	{
+		snapshot.adapterLines.clear();
+	}
+	return snapshot;
+}
+
+int runDoctor(const std::string &binaryName, const DoctorOptions &options)
+{
+	applyCommonOptions(options.common);
+	registerLoggers();
+	const auto snapshot = collectDoctorSnapshot(options);
+	const auto report = bzp::standalone::evaluateDoctorSnapshot(snapshot, binaryName);
+	printBlock(bzp::standalone::formatDoctorReport(report, binaryName));
+	return bzp::standalone::exitCodeForDoctorReport(report);
+}
+
+int runInspect(const std::string &binaryName, const InspectOptions &options)
+{
+	bzp::standalone::InspectSessionStore store;
+	std::string error;
+	auto snapshot = store.load(&error);
+	if (!snapshot)
+	{
+		if (!error.empty())
+		{
+			std::cerr << "ERROR: " << error << std::endl;
+			return 1;
+		}
+		printBlock(bzp::standalone::formatMissingSessionReport(binaryName));
+		return 1;
+	}
+	if (bzp::standalone::isInspectSessionStale(*snapshot, isProcessAlive))
+	{
+		store.clear();
+		printBlock(bzp::standalone::formatStaleSessionReport(*snapshot, binaryName));
+		return 1;
+	}
+
+	printBlock(bzp::standalone::formatInspectReport(*snapshot, binaryName, options.verboseEvents, options.showTree));
+	long long lastUpdatedAt = snapshot->updatedAtMs;
+
+	while (options.live)
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(options.refreshMs));
+
+		std::string refreshedError;
+		auto refreshed = store.load(&refreshedError);
+		if (!refreshed)
+		{
+			if (!refreshedError.empty())
+			{
+				std::cerr << "ERROR: " << refreshedError << std::endl;
+				return 1;
+			}
+			std::cout << '\n';
+			printBlock("BzPeri Inspect\nSTATUS  WARN\nManaged session ended.\n\nNEXT\nrun: " + binaryName + " demo\n");
+			return 0;
+		}
+		if (bzp::standalone::isInspectSessionStale(*refreshed, isProcessAlive))
+		{
+			store.clear();
+			std::cout << '\n';
+			printBlock(bzp::standalone::formatStaleSessionReport(*refreshed, binaryName));
+			return 1;
+		}
+
+		if (refreshed->updatedAtMs == lastUpdatedAt)
+		{
+			continue;
+		}
+
+		lastUpdatedAt = refreshed->updatedAtMs;
+		std::cout << '\n';
+		printBlock(bzp::standalone::formatInspectReport(*refreshed, binaryName, options.verboseEvents, options.showTree));
+	}
+
+	return 0;
+}
+
+int runDemo(const std::string &binaryName, const DemoOptions &options)
+{
+	applyCommonOptions(options.common);
+	registerLoggers();
+	clearInspectSession();
+
+	DemoOptions validated = options;
+	if (validateDemoOptions(&validated) != 0)
+	{
+		return -1;
+	}
+
+	configureDemoServices(validated);
+
+	installSignalHandler(SIGINT);
+	installSignalHandler(SIGTERM);
+	pendingShutdownSignal = 0;
+
+	bzpSetPrepareForSleepIntegrationEnabled(validated.sleepIntegrationEnabled ? 1 : 0);
+	bzpSetSleepInhibitorEnabled(validated.sleepInhibitorEnabled ? 1 : 0);
+	bzpSetGLibLogCaptureMode(validated.glibCaptureMode);
+	bzpSetGLibLogCaptureTargets(validated.glibCaptureTargets);
+	bzpSetGLibLogCaptureDomains(validated.glibCaptureDomains);
 
 	bool hostManagedCaptureInstalled = false;
-	if (installHostManagedCapture)
+	if (validated.installHostManagedCapture)
 	{
 		hostManagedCaptureInstalled = bzpInstallGLibLogCapture() != 0;
 		if (!hostManagedCaptureInstalled)
@@ -764,45 +1812,109 @@ int main(int argc, char **ppArgv)
 		}
 	}
 
-	if (manualLoopMode)
-	{
-		LogStatus("Using manual BzPeri run-loop mode");
-	}
-
-	// Start the server's ascync processing
-	//
-	// This starts the server on a thread and begins the initialization process
-	//
-	// !!!IMPORTANT!!!
-	//
-	//     This first parameter (the service name) must match tha name configured in the D-Bus permissions. See the Readme.md file
-	//     for more information.
-	//
-	//     The last parameter (enableBondable=1) allows client devices to pair/bond with this server. This is typically
-	//     required for modern BLE applications. Set to 0 to disable pairing if you need an open, non-authenticated connection.
-	//
-	const int started = manualLoopMode
-		? bzpStartWithBondableManual(serviceName.c_str(), advertisingName.c_str(), advertisingShortName.c_str(), dataGetter, dataSetter, 1)
-		: bzpStartWithBondable(serviceName.c_str(), advertisingName.c_str(), advertisingShortName.c_str(), dataGetter, dataSetter, kMaxAsyncInitTimeoutMS, 1);
-	if (!started)
-	{
+	auto cleanupAndReturn = [&](int code) {
+		clearInspectSession();
 		if (hostManagedCaptureInstalled)
 		{
 			bzpRestoreGLibLogCapture();
 		}
-		return -1;
+		return code;
+	};
+
+	LogStatus((std::string("Compiled log level: ") + describeCompiledLogLevel(bzpGetConfiguredCompiledLogLevel())).c_str());
+	LogStatus((std::string("PrepareForSleep integration: ") + (validated.sleepIntegrationEnabled ? "enabled" : "disabled")).c_str());
+	LogStatus((std::string("Sleep inhibitor integration: ") + (validated.sleepInhibitorEnabled ? "enabled" : "disabled")).c_str());
+	LogStatus((std::string("GLib log capture targets: ") + describeGLibCaptureTargets(validated.glibCaptureTargets)).c_str());
+	LogStatus((std::string("GLib log capture domains: ") + describeGLibCaptureDomains(validated.glibCaptureDomains)).c_str());
+
+	const int started = validated.manualLoopMode
+		? bzpStartWithBondableManual(validated.serviceName.c_str(), validated.advertisingName.c_str(), validated.advertisingShortName.c_str(), dataGetter, dataSetter, 1)
+		: bzpStartWithBondable(validated.serviceName.c_str(), validated.advertisingName.c_str(), validated.advertisingShortName.c_str(), dataGetter, dataSetter, kMaxAsyncInitTimeoutMS, 1);
+	if (!started)
+	{
+		DoctorOptions followupOptions;
+		followupOptions.common = validated.common;
+		const auto failureSnapshot = collectDoctorSnapshot(followupOptions, "com." + validated.serviceName);
+		const auto failureReport = bzp::standalone::evaluateDoctorSnapshot(failureSnapshot, binaryName);
+		std::ostringstream failure;
+		failure << "BzPeri Demo\n";
+		failure << "STATUS  FAIL\n";
+		failure << "Managed sample session failed before it could publish com." << validated.serviceName << ".\n\n";
+		failure << "WARNINGS\n";
+		for (const auto &check : failureReport.checks)
+		{
+			if (check.verdict == bzp::standalone::Verdict::Pass)
+			{
+				continue;
+			}
+			failure << bzp::standalone::verdictLabel(check.verdict) << "  " << check.label << '\n';
+			failure << "      " << check.detail << '\n';
+		}
+		failure << "\nNEXT\n";
+		failure << "run: " << binaryName << " doctor\n";
+		for (const auto &command : failureReport.nextCommands)
+		{
+			failure << "run: " << command << '\n';
+		}
+		printBlock(failure.str());
+		return cleanupAndReturn(-1);
 	}
 
-	// Wait for the server to start the shutdown process
-	//
-	// While we wait, every 15 ticks, drop the battery level by one percent until we reach 0
+	auto snapshot = buildInspectSnapshot(validated);
+	{
+		std::lock_guard<std::recursive_mutex> lock(inspectSessionMutex);
+		inspectSessionStore = std::make_unique<bzp::standalone::InspectSessionStore>();
+		if (snapshot)
+		{
+			inspectSessionSnapshot = std::make_unique<bzp::standalone::InspectSessionSnapshot>(*snapshot);
+		}
+		else
+		{
+			inspectSessionSnapshot.reset();
+		}
+	}
+	if (snapshot)
+	{
+		persistInspectSession();
+	}
+
+	std::ostringstream success;
+	success << "BzPeri Demo\n";
+	success << "STATUS  PASS\n";
+	success << "Managed sample session is advertising and ready.\n\n";
+	success << "FACTS\n";
+	success << "service: " << validated.serviceName << '\n';
+	success << "advertising: " << validated.advertisingName << '\n';
+	success << "sample namespace: " << validated.sampleNamespace << '\n';
+	success << "loop mode: " << (validated.manualLoopMode ? "manual" : "threaded") << '\n';
+	if (snapshot)
+	{
+		success << "adapter: " << snapshot->adapterPath;
+		if (!snapshot->adapterAddress.empty())
+		{
+			success << " [" << snapshot->adapterAddress << "]";
+		}
+		success << '\n';
+		success << "advertising active: " << (snapshot->advertisingEnabled ? "yes" : "no") << '\n';
+		success << "object root: " << snapshot->objectRoot << '\n';
+		success << "probe path: " << snapshot->selectedObjectPath << '\n';
+		if (!snapshot->writeProbePath.empty())
+		{
+			success << "write probe: " << snapshot->writeProbePath << '\n';
+		}
+	}
+	success << "\nNEXT\n";
+	success << "run: Ctrl-C to stop the demo\n";
+	success << "run: " << binaryName << " inspect --live\n";
+	printBlock(success.str());
+
 	bool shutdownTriggered = false;
 	int batteryTickSeconds = 0;
 	constexpr auto kLoopTick = std::chrono::milliseconds(100);
 	auto lastTick = std::chrono::steady_clock::now();
 	while (bzpGetServerRunState() < EStopping)
 	{
-		if (manualLoopMode)
+		if (validated.manualLoopMode)
 		{
 			bzpRunLoopIterationFor(static_cast<int>(kLoopTick.count()));
 		}
@@ -815,18 +1927,19 @@ int main(int argc, char **ppArgv)
 		{
 			switch (pendingShutdownSignal)
 			{
-				case SIGINT:
-					LogStatus("SIGINT received, shutting down");
-					break;
-				case SIGTERM:
-					LogStatus("SIGTERM received, shutting down");
-					break;
-				default:
-					LogStatus("Termination signal received, shutting down");
-					break;
+			case SIGINT:
+				LogStatus("SIGINT received, shutting down");
+				break;
+			case SIGTERM:
+				LogStatus("SIGTERM received, shutting down");
+				break;
+			default:
+				LogStatus("Termination signal received, shutting down");
+				break;
 			}
 			bzpTriggerShutdown();
 			shutdownTriggered = true;
+			refreshInspectSession(false);
 		}
 
 		const auto now = std::chrono::steady_clock::now();
@@ -847,10 +1960,19 @@ int main(int argc, char **ppArgv)
 		if (!batteryLevelObjectPath.empty())
 		{
 			bzpNotifyUpdatedCharacteristic(batteryLevelObjectPath.c_str());
+			recordInspectSemanticEvent(
+				bzp::standalone::EventLevel::Status,
+				"gatt",
+				std::string("notify path=") + batteryLevelObjectPath + " value=" + std::to_string(serverDataBatteryLevel) + "%",
+				true);
+		}
+		else
+		{
+			refreshInspectSession(false);
 		}
 	}
 
-	if (manualLoopMode)
+	if (validated.manualLoopMode)
 	{
 		while (bzpGetServerRunState() != EStopped)
 		{
@@ -862,35 +1984,92 @@ int main(int argc, char **ppArgv)
 
 		if (!bzpWaitForShutdown(0))
 		{
-			if (hostManagedCaptureInstalled)
-			{
-				bzpRestoreGLibLogCapture();
-			}
-			return -1;
+			return cleanupAndReturn(-1);
 		}
-
-		if (hostManagedCaptureInstalled)
-		{
-			bzpRestoreGLibLogCapture();
-		}
-		return bzpGetServerHealth() == EOk ? 0 : 1;
+		return cleanupAndReturn(bzpGetServerHealth() == EOk ? 0 : 1);
 	}
 
-	// Wait for the server to come to a complete stop (CTRL-C from the command line)
 	if (!bzpWait())
 	{
-		if (hostManagedCaptureInstalled)
-		{
-			bzpRestoreGLibLogCapture();
-		}
-		return -1;
+		return cleanupAndReturn(-1);
 	}
 
-	if (hostManagedCaptureInstalled)
+	return cleanupAndReturn(bzpGetServerHealth() == EOk ? 0 : 1);
+}
+
+} // namespace
+
+int main(int argc, char **ppArgv)
+{
+	const std::string binaryName = executableName(ppArgv != nullptr ? ppArgv[0] : "bzp-standalone");
+	const auto command = selectCommand(argc, ppArgv);
+	if (command.optionStartIndex == 0)
 	{
-		bzpRestoreGLibLogCapture();
+		std::cerr << "ERROR: unknown subcommand '" << ppArgv[1] << "'\n\n";
+		printBlock(buildTopLevelHelp(binaryName));
+		return 1;
 	}
 
-	// Return the final server health status as a success (0) or error (-1)
-  	return bzpGetServerHealth() == EOk ? 0 : 1;
+	if (command.mode == CommandMode::TopLevelHelp)
+	{
+		printBlock(buildTopLevelHelp(binaryName));
+		return 0;
+	}
+
+	std::string error;
+	switch (command.mode)
+	{
+	case CommandMode::Demo:
+	{
+		DemoOptions options;
+		if (!parseDemoOptions(argc, ppArgv, command.optionStartIndex, &options, &error))
+		{
+			std::cerr << "ERROR: " << error << "\n\n";
+			printBlock(buildDemoHelp(binaryName));
+			return 1;
+		}
+		if (options.showHelp)
+		{
+			printBlock(buildDemoHelp(binaryName));
+			return 0;
+		}
+		return runDemo(binaryName, options);
+	}
+	case CommandMode::Doctor:
+	{
+		DoctorOptions options;
+		if (!parseDoctorOptions(argc, ppArgv, command.optionStartIndex, &options, &error))
+		{
+			std::cerr << "ERROR: " << error << "\n\n";
+			printBlock(buildDoctorHelp(binaryName));
+			return 1;
+		}
+		if (options.showHelp)
+		{
+			printBlock(buildDoctorHelp(binaryName));
+			return 0;
+		}
+		return runDoctor(binaryName, options);
+	}
+	case CommandMode::Inspect:
+	{
+		InspectOptions options;
+		if (!parseInspectOptions(argc, ppArgv, command.optionStartIndex, &options, &error))
+		{
+			std::cerr << "ERROR: " << error << "\n\n";
+			printBlock(buildInspectHelp(binaryName));
+			return 1;
+		}
+		if (options.showHelp)
+		{
+			printBlock(buildInspectHelp(binaryName));
+			return 0;
+		}
+		return runInspect(binaryName, options);
+	}
+	case CommandMode::TopLevelHelp:
+	default:
+		printBlock(buildTopLevelHelp(binaryName));
+		return 0;
+	}
 }

--- a/scripts/configure-bluez-experimental.sh
+++ b/scripts/configure-bluez-experimental.sh
@@ -41,6 +41,16 @@ check_bluez() {
 check_current_status() {
     print_info "Checking current BlueZ configuration..."
 
+    local running_process
+    running_process=$(get_running_bluetoothd_command 2>/dev/null)
+    if [ -n "$running_process" ]; then
+        print_info "Running process: $running_process"
+        if has_experimental_flag "$running_process"; then
+            print_success "BlueZ experimental mode is enabled"
+            return 0
+        fi
+    fi
+
     # Get current command
     local current_command
     current_command=$(get_current_execstart 2>/dev/null)
@@ -61,6 +71,11 @@ check_current_status() {
     fi
 }
 
+# Function to get the currently running bluetoothd command line
+get_running_bluetoothd_command() {
+    ps -eo args= | grep '[b]luetoothd' | head -1
+}
+
 # Function to backup current configuration
 backup_config() {
     local backup_dir="/etc/systemd/system/bluetooth.service.d"
@@ -79,7 +94,14 @@ backup_config() {
 get_current_execstart() {
     local full_command=""
 
-    # Method 1: Get from systemctl show (most reliable)
+    # Method 1: Parse the effective ExecStart from systemctl cat output so drop-ins win.
+    local unit_command=$(systemctl cat bluetooth.service 2>/dev/null | grep "^ExecStart=" | tail -1 | sed 's/ExecStart=//')
+    if [ -n "$unit_command" ]; then
+        echo "$unit_command"
+        return 0
+    fi
+
+    # Method 2: Get from systemctl show
     local show_output=$(systemctl show bluetooth.service -p ExecStart --value 2>/dev/null)
     if [ -n "$show_output" ]; then
         # Extract the actual command from systemctl show output
@@ -90,13 +112,6 @@ get_current_execstart() {
             echo "$full_command"
             return 0
         fi
-    fi
-
-    # Method 2: Parse unit file directly
-    local unit_command=$(systemctl cat bluetooth.service 2>/dev/null | grep "^ExecStart=" | head -1 | sed 's/ExecStart=//')
-    if [ -n "$unit_command" ]; then
-        echo "$unit_command"
-        return 0
     fi
 
     # Method 3: Find common bluetoothd paths

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -106,6 +106,21 @@ static std::string bluezGattManagerInterfaceName = "";
 static Server* pServerContext = nullptr;
 static BluezAdapter* pAdapterContext = nullptr;
 
+static void removeSourceIfPresent(guint *sourceId)
+{
+	if (sourceId == nullptr || *sourceId == 0)
+	{
+		return;
+	}
+
+	GMainContext *context = pMainContext != nullptr ? pMainContext : g_main_context_default();
+	if (g_main_context_find_source_by_id(context, *sourceId) != nullptr)
+	{
+		g_source_remove(*sourceId);
+	}
+	*sourceId = 0;
+}
+
 //
 // Externs
 //
@@ -804,26 +819,22 @@ void uninit()
 
 	if (0 != periodicTimeoutId)
 	{
-		g_source_remove(periodicTimeoutId);
-		periodicTimeoutId = 0;
+		removeSourceIfPresent(&periodicTimeoutId);
 	}
 
 	if (0 != updateProcessorSourceId)
 	{
-		g_source_remove(updateProcessorSourceId);
-		updateProcessorSourceId = 0;
+		removeSourceIfPresent(&updateProcessorSourceId);
 	}
 
 	if (0 != sigtermSourceId)
 	{
-		g_source_remove(sigtermSourceId);
-		sigtermSourceId = 0;
+		removeSourceIfPresent(&sigtermSourceId);
 	}
 
 	if (0 != sigintSourceId)
 	{
-		g_source_remove(sigintSourceId);
-		sigintSourceId = 0;
+		removeSourceIfPresent(&sigintSourceId);
 	}
 
 	if (0 != sleepSignalSubscriptionId)

--- a/src/StandaloneWorkflow.cpp
+++ b/src/StandaloneWorkflow.cpp
@@ -1,0 +1,794 @@
+#include "StandaloneWorkflow.h"
+
+#include <gio/gio.h>
+
+#include <algorithm>
+#include <chrono>
+#include <ctime>
+#include <exception>
+#include <filesystem>
+#include <iomanip>
+#include <sstream>
+#include <utility>
+
+namespace bzp::standalone {
+
+namespace {
+
+constexpr int kSessionFormatVersion = 2;
+constexpr std::size_t kDefaultInspectEventDisplayCount = 8;
+constexpr std::size_t kVerboseInspectEventDisplayCount = 16;
+
+std::string joinCommands(const std::vector<std::string> &commands)
+{
+	std::ostringstream stream;
+	for (std::size_t i = 0; i < commands.size(); ++i)
+	{
+		if (i != 0)
+		{
+			stream << '\n';
+		}
+		stream << "run: " << commands[i];
+	}
+	return stream.str();
+}
+
+void appendSection(std::ostringstream &stream, const std::string &title)
+{
+	stream << '\n' << title << '\n';
+}
+
+void appendCheckLines(std::ostringstream &stream, const DoctorCheck &check)
+{
+	stream << verdictLabel(check.verdict) << "  " << check.label << '\n';
+	stream << "      " << check.detail << '\n';
+}
+
+std::string formatTimestamp(long long timestampMs)
+{
+	if (timestampMs <= 0)
+	{
+		return "--:--:--";
+	}
+
+	const std::time_t seconds = static_cast<std::time_t>(timestampMs / 1000);
+	std::tm localTime = {};
+	localtime_r(&seconds, &localTime);
+
+	std::ostringstream stream;
+	stream << std::put_time(&localTime, "%H:%M:%S");
+	return stream.str();
+}
+
+void appendStringList(GKeyFile *keyFile, const char *group, const char *key, const std::vector<std::string> &values)
+{
+	if (values.empty())
+	{
+		return;
+	}
+
+	std::vector<const gchar *> stringRefs;
+	stringRefs.reserve(values.size());
+	for (const auto &value : values)
+	{
+		stringRefs.push_back(value.c_str());
+	}
+
+	g_key_file_set_string_list(keyFile, group, key, stringRefs.data(), stringRefs.size());
+}
+
+std::vector<std::string> loadStringList(GKeyFile *keyFile, const char *group, const char *key)
+{
+	gsize length = 0;
+	GError *error = nullptr;
+	gchar **values = g_key_file_get_string_list(keyFile, group, key, &length, &error);
+	if (values == nullptr)
+	{
+		if (error != nullptr)
+		{
+			g_error_free(error);
+		}
+		return {};
+	}
+
+	std::vector<std::string> result;
+	result.reserve(length);
+	for (gsize i = 0; i < length; ++i)
+	{
+		result.emplace_back(values[i] != nullptr ? values[i] : "");
+	}
+	g_strfreev(values);
+	return result;
+}
+
+std::string loadStringValue(GKeyFile *keyFile, const char *group, const char *key)
+{
+	GError *error = nullptr;
+	gchar *value = g_key_file_get_string(keyFile, group, key, &error);
+	if (value == nullptr)
+	{
+		if (error != nullptr)
+		{
+			g_error_free(error);
+		}
+		return "";
+	}
+
+	std::string result(value);
+	g_free(value);
+	return result;
+}
+
+int loadIntegerValue(GKeyFile *keyFile, const char *group, const char *key, int fallback = 0)
+{
+	GError *error = nullptr;
+	const int value = g_key_file_get_integer(keyFile, group, key, &error);
+	if (error != nullptr)
+	{
+		g_error_free(error);
+		return fallback;
+	}
+	return value;
+}
+
+long long loadInt64Value(GKeyFile *keyFile, const char *group, const char *key, long long fallback = 0)
+{
+	GError *error = nullptr;
+	const gint64 value = g_key_file_get_int64(keyFile, group, key, &error);
+	if (error != nullptr)
+	{
+		g_error_free(error);
+		return fallback;
+	}
+	return static_cast<long long>(value);
+}
+
+bool loadBooleanValue(GKeyFile *keyFile, const char *group, const char *key, bool fallback = false)
+{
+	GError *error = nullptr;
+	const gboolean value = g_key_file_get_boolean(keyFile, group, key, &error);
+	if (error != nullptr)
+	{
+		g_error_free(error);
+		return fallback;
+	}
+	return value != FALSE;
+}
+
+void setError(std::string *errorOut, std::string message)
+{
+	if (errorOut != nullptr)
+	{
+		*errorOut = std::move(message);
+	}
+}
+
+} // namespace
+
+DoctorSnapshot collectDoctorSnapshot(const DoctorProbe &probe, const std::string &preferredAdapter, const std::string &ownedName)
+{
+	DoctorSnapshot snapshot;
+	snapshot.systemBusReachable = probe.checkSystemBus(&snapshot.systemBusDetail);
+	if (!snapshot.systemBusReachable)
+	{
+		return snapshot;
+	}
+
+	snapshot.bluezServiceReachable = probe.checkBluezService(&snapshot.bluezServiceDetail);
+	snapshot.serviceNameAvailable = probe.checkServiceOwnership(ownedName, &snapshot.serviceNameDetail);
+	snapshot.policyInstalled = probe.checkPolicy(&snapshot.policyPath);
+	snapshot.experimentalHelperAvailable = probe.checkExperimentalHelper(
+		&snapshot.experimentalHelperPath,
+		&snapshot.experimentalModeEnabled,
+		&snapshot.experimentalDetail);
+	snapshot.adapterProbeSucceeded = probe.probeAdapter(
+		preferredAdapter,
+		&snapshot.poweredAdapterAvailable,
+		&snapshot.adapterSummary,
+		&snapshot.adapterLines,
+		&snapshot.adapterProbeDetail);
+	return snapshot;
+}
+
+DoctorReport evaluateDoctorSnapshot(const DoctorSnapshot &snapshot, const std::string &binaryName)
+{
+	DoctorReport report;
+	report.adapterLines = snapshot.adapterLines;
+	report.checks = {
+		{"System bus", snapshot.systemBusReachable ? Verdict::Pass : Verdict::Fail,
+			snapshot.systemBusReachable ? snapshot.systemBusDetail : (snapshot.systemBusDetail.empty() ? "Failed to connect to the system D-Bus." : snapshot.systemBusDetail)},
+		{"BlueZ service", snapshot.bluezServiceReachable ? Verdict::Pass : Verdict::Fail,
+			snapshot.bluezServiceReachable ? snapshot.bluezServiceDetail : (snapshot.bluezServiceDetail.empty() ? "org.bluez is not currently owned on the system bus." : snapshot.bluezServiceDetail)},
+		{"D-Bus owned name", snapshot.serviceNameAvailable ? Verdict::Pass : Verdict::Fail,
+			snapshot.serviceNameAvailable ? snapshot.serviceNameDetail : (snapshot.serviceNameDetail.empty() ? "Current process could not own com.bzperi on the system bus." : snapshot.serviceNameDetail)},
+		{"Adapter readiness",
+			(!snapshot.adapterProbeSucceeded || !snapshot.poweredAdapterAvailable) ? Verdict::Fail : Verdict::Pass,
+			(!snapshot.adapterProbeSucceeded || !snapshot.poweredAdapterAvailable)
+				? (!snapshot.adapterProbeDetail.empty() ? snapshot.adapterProbeDetail : "No powered BLE adapter is ready for BzPeri.")
+				: snapshot.adapterSummary},
+		{"D-Bus policy", snapshot.policyInstalled ? Verdict::Pass : Verdict::Fail,
+			snapshot.policyInstalled
+				? ("Found " + snapshot.policyPath)
+				: ("Missing required policy file: " + (snapshot.policyPath.empty() ? "/etc/dbus-1/system.d/com.bzperi.conf" : snapshot.policyPath))},
+		{"BlueZ experimental mode",
+			!snapshot.experimentalHelperAvailable ? Verdict::Warn : (snapshot.experimentalModeEnabled ? Verdict::Pass : Verdict::Warn),
+			snapshot.experimentalHelperAvailable
+				? (snapshot.experimentalDetail.empty()
+					? (snapshot.experimentalModeEnabled
+						? "Experimental mode is enabled."
+						: "Experimental mode is not enabled.")
+					: snapshot.experimentalDetail)
+				: (snapshot.experimentalDetail.empty() ? "BlueZ experimental helper not found; use manual bluetoothd --experimental guidance if needed." : snapshot.experimentalDetail)},
+	};
+
+	const bool hasFail = std::any_of(report.checks.begin(), report.checks.end(), [](const DoctorCheck &check) {
+		return check.verdict == Verdict::Fail;
+	});
+	const bool hasWarn = std::any_of(report.checks.begin(), report.checks.end(), [](const DoctorCheck &check) {
+		return check.verdict == Verdict::Warn;
+	});
+	report.overall = hasFail ? Verdict::Fail : (hasWarn ? Verdict::Warn : Verdict::Pass);
+
+	auto addNextCommand = [&report](const std::string &command) {
+		if (std::find(report.nextCommands.begin(), report.nextCommands.end(), command) == report.nextCommands.end())
+		{
+			report.nextCommands.push_back(command);
+		}
+	};
+
+	if (!snapshot.systemBusReachable)
+	{
+		addNextCommand("sudo systemctl status dbus");
+	}
+
+	if (!snapshot.bluezServiceReachable)
+	{
+		addNextCommand("sudo systemctl status bluetooth");
+	}
+
+	if (!snapshot.serviceNameAvailable)
+	{
+		addNextCommand("sudo " + binaryName + " doctor");
+		addNextCommand("sudo " + binaryName + " demo");
+	}
+
+	if (!snapshot.adapterProbeSucceeded)
+	{
+		addNextCommand("sudo bluetoothctl list");
+	}
+	else if (!snapshot.poweredAdapterAvailable)
+	{
+		addNextCommand("sudo bluetoothctl power on");
+		addNextCommand(binaryName + " demo --list-adapters");
+	}
+
+	if (!snapshot.policyInstalled)
+	{
+		addNextCommand("sudo cp dbus/com.bzperi.conf /etc/dbus-1/system.d/");
+		addNextCommand("sudo systemctl reload dbus");
+	}
+
+	if (snapshot.experimentalHelperAvailable)
+	{
+		addNextCommand("sudo " + snapshot.experimentalHelperPath + " status");
+		if (!snapshot.experimentalModeEnabled)
+		{
+			addNextCommand("sudo " + snapshot.experimentalHelperPath + " enable");
+		}
+	}
+
+	if (report.overall != Verdict::Fail)
+	{
+		addNextCommand(binaryName + " demo");
+	}
+
+	return report;
+}
+
+int exitCodeForDoctorReport(const DoctorReport &report) noexcept
+{
+	return report.overall == Verdict::Fail ? 1 : 0;
+}
+
+std::string formatDoctorReport(const DoctorReport &report, const std::string &binaryName)
+{
+	std::ostringstream stream;
+	stream << "BzPeri Doctor\n";
+	stream << "STATUS  " << verdictLabel(report.overall) << '\n';
+	stream << "Checks the local host for the " << binaryName << " happy path.\n";
+
+	appendSection(stream, "CHECKS");
+	for (const auto &check : report.checks)
+	{
+		appendCheckLines(stream, check);
+	}
+
+	if (!report.adapterLines.empty())
+	{
+		appendSection(stream, "ADAPTERS");
+		for (const auto &line : report.adapterLines)
+		{
+			stream << line << '\n';
+		}
+	}
+
+	appendSection(stream, "NEXT");
+	stream << joinCommands(report.nextCommands) << '\n';
+	return stream.str();
+}
+
+std::string verdictLabel(Verdict verdict)
+{
+	switch (verdict)
+	{
+	case Verdict::Pass:
+		return "PASS";
+	case Verdict::Warn:
+		return "WARN";
+	case Verdict::Fail:
+	default:
+		return "FAIL";
+	}
+}
+
+InspectSessionStore::InspectSessionStore(std::string path, std::size_t eventLimit)
+	: path_(std::move(path)),
+	  eventLimit_(eventLimit)
+{
+}
+
+std::string InspectSessionStore::defaultSessionPath()
+{
+	try
+	{
+		const gchar *runtimeDir = g_get_user_runtime_dir();
+		std::filesystem::path basePath = (runtimeDir != nullptr && *runtimeDir != '\0')
+			? std::filesystem::path(runtimeDir)
+			: std::filesystem::temp_directory_path();
+		basePath /= "bzperi";
+		basePath /= "bzp-standalone-session.ini";
+		return basePath.string();
+	}
+	catch (...)
+	{
+		return "/tmp/bzperi/bzp-standalone-session.ini";
+	}
+}
+
+bool InspectSessionStore::save(const InspectSessionSnapshot &snapshot, std::string *errorOut) const
+{
+	try
+	{
+		const std::filesystem::path filePath(path_);
+		if (filePath.has_parent_path())
+		{
+			std::filesystem::create_directories(filePath.parent_path());
+		}
+	}
+	catch (const std::exception &error)
+	{
+		setError(errorOut, error.what());
+		return false;
+	}
+
+	GKeyFile *keyFile = g_key_file_new();
+	g_key_file_set_integer(keyFile, "session", "format_version", snapshot.formatVersion);
+	g_key_file_set_integer(keyFile, "session", "pid", snapshot.pid);
+	g_key_file_set_int64(keyFile, "session", "updated_at_ms", snapshot.updatedAtMs);
+	g_key_file_set_string(keyFile, "session", "service_name", snapshot.serviceName.c_str());
+	g_key_file_set_string(keyFile, "session", "advertising_name", snapshot.advertisingName.c_str());
+	g_key_file_set_string(keyFile, "session", "advertising_short_name", snapshot.advertisingShortName.c_str());
+	g_key_file_set_string(keyFile, "session", "sample_namespace", snapshot.sampleNamespace.c_str());
+	g_key_file_set_string(keyFile, "session", "object_root", snapshot.objectRoot.c_str());
+	g_key_file_set_string(keyFile, "session", "selected_object_path", snapshot.selectedObjectPath.c_str());
+	g_key_file_set_string(keyFile, "session", "write_probe_path", snapshot.writeProbePath.c_str());
+	g_key_file_set_string(keyFile, "session", "selected_object_summary", snapshot.selectedObjectSummary.c_str());
+	g_key_file_set_string(keyFile, "session", "adapter_path", snapshot.adapterPath.c_str());
+	g_key_file_set_string(keyFile, "session", "adapter_address", snapshot.adapterAddress.c_str());
+	g_key_file_set_string(keyFile, "session", "adapter_alias", snapshot.adapterAlias.c_str());
+	g_key_file_set_boolean(keyFile, "session", "adapter_powered", snapshot.adapterPowered);
+	g_key_file_set_boolean(keyFile, "session", "include_sample_services", snapshot.includeSampleServices);
+	g_key_file_set_boolean(keyFile, "session", "manual_loop_mode", snapshot.manualLoopMode);
+	g_key_file_set_boolean(keyFile, "session", "advertising_enabled", snapshot.advertisingEnabled);
+	g_key_file_set_integer(keyFile, "session", "active_connections", snapshot.activeConnections);
+	g_key_file_set_integer(keyFile, "session", "object_count", snapshot.objectCount);
+	g_key_file_set_integer(keyFile, "session", "run_state", snapshot.runState);
+	g_key_file_set_integer(keyFile, "session", "health", snapshot.health);
+	g_key_file_set_int64(keyFile, "session", "dropped_event_count", static_cast<gint64>(snapshot.droppedEventCount));
+
+	appendStringList(keyFile, "session", "object_tree", snapshot.objectTreeLines);
+	appendStringList(keyFile, "session", "selected_object_lines", snapshot.selectedObjectLines);
+	appendStringList(keyFile, "session", "warnings", snapshot.warnings);
+
+	g_key_file_set_integer(keyFile, "events", "count", static_cast<int>(snapshot.events.size()));
+	for (std::size_t index = 0; index < snapshot.events.size(); ++index)
+	{
+		const auto group = "event_" + std::to_string(index);
+		g_key_file_set_int64(keyFile, group.c_str(), "timestamp_ms", snapshot.events[index].timestampMs);
+		g_key_file_set_string(keyFile, group.c_str(), "level", eventLevelLabel(snapshot.events[index].level).c_str());
+		g_key_file_set_string(keyFile, group.c_str(), "component", snapshot.events[index].component.c_str());
+		g_key_file_set_string(keyFile, group.c_str(), "message", snapshot.events[index].message.c_str());
+	}
+
+	gsize dataSize = 0;
+	GError *error = nullptr;
+	gchar *data = g_key_file_to_data(keyFile, &dataSize, &error);
+	if (data == nullptr)
+	{
+		setError(errorOut, error != nullptr ? error->message : "Failed to serialize inspect session");
+		if (error != nullptr)
+		{
+			g_error_free(error);
+		}
+		g_key_file_unref(keyFile);
+		return false;
+	}
+
+	const gboolean writeResult = g_file_set_contents(path_.c_str(), data, static_cast<gssize>(dataSize), &error);
+	g_free(data);
+	g_key_file_unref(keyFile);
+	if (writeResult == FALSE)
+	{
+		setError(errorOut, error != nullptr ? error->message : "Failed to write inspect session file");
+		if (error != nullptr)
+		{
+			g_error_free(error);
+		}
+		return false;
+	}
+
+	return true;
+}
+
+std::optional<InspectSessionSnapshot> InspectSessionStore::load(std::string *errorOut) const
+{
+	GError *error = nullptr;
+	GKeyFile *keyFile = g_key_file_new();
+	const gboolean loaded = g_key_file_load_from_file(keyFile, path_.c_str(), G_KEY_FILE_NONE, &error);
+	if (loaded == FALSE)
+	{
+		if (error != nullptr && error->domain == G_FILE_ERROR && error->code == G_FILE_ERROR_NOENT)
+		{
+			g_error_free(error);
+			g_key_file_unref(keyFile);
+			return std::nullopt;
+		}
+
+		setError(errorOut, error != nullptr ? error->message : "Failed to read inspect session file");
+		if (error != nullptr)
+		{
+			g_error_free(error);
+		}
+		g_key_file_unref(keyFile);
+		return std::nullopt;
+	}
+
+	InspectSessionSnapshot snapshot;
+	snapshot.formatVersion = loadIntegerValue(keyFile, "session", "format_version", kSessionFormatVersion);
+	snapshot.pid = loadIntegerValue(keyFile, "session", "pid", 0);
+	snapshot.updatedAtMs = loadInt64Value(keyFile, "session", "updated_at_ms", 0);
+	snapshot.serviceName = loadStringValue(keyFile, "session", "service_name");
+	snapshot.advertisingName = loadStringValue(keyFile, "session", "advertising_name");
+	snapshot.advertisingShortName = loadStringValue(keyFile, "session", "advertising_short_name");
+	snapshot.sampleNamespace = loadStringValue(keyFile, "session", "sample_namespace");
+	snapshot.objectRoot = loadStringValue(keyFile, "session", "object_root");
+	snapshot.selectedObjectPath = loadStringValue(keyFile, "session", "selected_object_path");
+	snapshot.writeProbePath = loadStringValue(keyFile, "session", "write_probe_path");
+	snapshot.selectedObjectSummary = loadStringValue(keyFile, "session", "selected_object_summary");
+	snapshot.adapterPath = loadStringValue(keyFile, "session", "adapter_path");
+	snapshot.adapterAddress = loadStringValue(keyFile, "session", "adapter_address");
+	snapshot.adapterAlias = loadStringValue(keyFile, "session", "adapter_alias");
+	snapshot.adapterPowered = loadBooleanValue(keyFile, "session", "adapter_powered", false);
+	snapshot.includeSampleServices = loadBooleanValue(keyFile, "session", "include_sample_services", true);
+	snapshot.manualLoopMode = loadBooleanValue(keyFile, "session", "manual_loop_mode", false);
+	snapshot.advertisingEnabled = loadBooleanValue(keyFile, "session", "advertising_enabled", false);
+	snapshot.activeConnections = loadIntegerValue(keyFile, "session", "active_connections", 0);
+	snapshot.objectCount = loadIntegerValue(keyFile, "session", "object_count", 0);
+	snapshot.runState = loadIntegerValue(keyFile, "session", "run_state", 0);
+	snapshot.health = loadIntegerValue(keyFile, "session", "health", 0);
+	snapshot.droppedEventCount = static_cast<std::size_t>(loadInt64Value(keyFile, "session", "dropped_event_count", 0));
+	snapshot.objectTreeLines = loadStringList(keyFile, "session", "object_tree");
+	snapshot.selectedObjectLines = loadStringList(keyFile, "session", "selected_object_lines");
+	snapshot.warnings = loadStringList(keyFile, "session", "warnings");
+
+	const int eventCount = loadIntegerValue(keyFile, "events", "count", 0);
+	for (int index = 0; index < eventCount; ++index)
+	{
+		const auto group = "event_" + std::to_string(index);
+		const auto levelText = loadStringValue(keyFile, group.c_str(), "level");
+		EventLevel level = EventLevel::Info;
+		if (levelText == "TRACE")
+		{
+			level = EventLevel::Trace;
+		}
+		else if (levelText == "DEBUG")
+		{
+			level = EventLevel::Debug;
+		}
+		else if (levelText == "STATUS")
+		{
+			level = EventLevel::Status;
+		}
+		else if (levelText == "WARN")
+		{
+			level = EventLevel::Warn;
+		}
+		else if (levelText == "ERROR")
+		{
+			level = EventLevel::Error;
+		}
+		else if (levelText == "FATAL")
+		{
+			level = EventLevel::Fatal;
+		}
+
+		snapshot.events.push_back({
+			loadInt64Value(keyFile, group.c_str(), "timestamp_ms", 0),
+			level,
+			loadStringValue(keyFile, group.c_str(), "component"),
+			loadStringValue(keyFile, group.c_str(), "message"),
+		});
+	}
+
+	g_key_file_unref(keyFile);
+	return snapshot;
+}
+
+bool InspectSessionStore::clear(std::string *errorOut) const
+{
+	std::error_code errorCode;
+	const bool removed = std::filesystem::remove(path_, errorCode);
+	if (!removed && errorCode)
+	{
+		setError(errorOut, errorCode.message());
+		return false;
+	}
+	return true;
+}
+
+long long currentTimeMs() noexcept
+{
+	return std::chrono::duration_cast<std::chrono::milliseconds>(
+		std::chrono::system_clock::now().time_since_epoch()).count();
+}
+
+void appendInspectEvent(InspectSessionSnapshot &snapshot, const InspectEvent &event, std::size_t eventLimit)
+{
+	snapshot.events.push_back(event);
+	if (snapshot.events.size() > eventLimit)
+	{
+		const auto overflowCount = snapshot.events.size() - eventLimit;
+		snapshot.events.erase(snapshot.events.begin(), snapshot.events.begin() + static_cast<std::ptrdiff_t>(overflowCount));
+		snapshot.droppedEventCount += overflowCount;
+	}
+	snapshot.updatedAtMs = currentTimeMs();
+}
+
+bool shouldDisplayEvent(const InspectEvent &event, bool verboseEvents) noexcept
+{
+	if (verboseEvents)
+	{
+		return true;
+	}
+
+	switch (event.level)
+	{
+	case EventLevel::Warn:
+	case EventLevel::Error:
+	case EventLevel::Fatal:
+	case EventLevel::Status:
+		return true;
+	case EventLevel::Info:
+		return event.message.find("op=Connection") != std::string::npos
+			|| event.message.find("op=Initialize") != std::string::npos
+			|| event.message.find("result=Failed") != std::string::npos
+			|| event.message.find("result=Retry") != std::string::npos;
+	case EventLevel::Trace:
+	case EventLevel::Debug:
+	default:
+		return false;
+	}
+}
+
+std::string eventLevelLabel(EventLevel level)
+{
+	switch (level)
+	{
+	case EventLevel::Trace:
+		return "TRACE";
+	case EventLevel::Debug:
+		return "DEBUG";
+	case EventLevel::Info:
+		return "INFO";
+	case EventLevel::Status:
+		return "STATUS";
+	case EventLevel::Warn:
+		return "WARN";
+	case EventLevel::Error:
+		return "ERROR";
+	case EventLevel::Fatal:
+	default:
+		return "FATAL";
+	}
+}
+
+std::string formatInspectReport(const InspectSessionSnapshot &snapshot, const std::string &binaryName, bool verboseEvents, bool showTree)
+{
+	std::ostringstream stream;
+	stream << "BzPeri Inspect\n";
+	stream << "STATUS  PASS\n";
+	stream << "Attached to managed session from pid " << snapshot.pid << ".\n";
+
+	appendSection(stream, "FACTS");
+	stream << "service: " << snapshot.serviceName << '\n';
+	stream << "advertising: " << snapshot.advertisingName;
+	if (!snapshot.advertisingShortName.empty())
+	{
+		stream << " (short: " << snapshot.advertisingShortName << ")";
+	}
+	stream << '\n';
+	stream << "adapter: " << snapshot.adapterPath;
+	if (!snapshot.adapterAddress.empty())
+	{
+		stream << " [" << snapshot.adapterAddress << "]";
+	}
+	stream << '\n';
+	stream << "adapter powered: " << (snapshot.adapterPowered ? "yes" : "no") << '\n';
+	stream << "sample services: " << (snapshot.includeSampleServices ? "enabled" : "disabled") << '\n';
+	stream << "loop mode: " << (snapshot.manualLoopMode ? "manual" : "threaded") << '\n';
+	stream << "object root: " << snapshot.objectRoot << '\n';
+	stream << "selected object: " << snapshot.selectedObjectPath << '\n';
+	if (!snapshot.writeProbePath.empty())
+	{
+		stream << "write probe: " << snapshot.writeProbePath << '\n';
+	}
+	stream << "objects: " << snapshot.objectCount << '\n';
+	stream << "active connections: " << snapshot.activeConnections << '\n';
+	stream << "advertising active: " << (snapshot.advertisingEnabled ? "yes" : "no") << '\n';
+	if (!showTree && !snapshot.objectTreeLines.empty())
+	{
+		stream << "tree: hidden by default (" << snapshot.objectTreeLines.size() << " lines)\n";
+	}
+
+	if (!snapshot.selectedObjectSummary.empty() || !snapshot.selectedObjectLines.empty())
+	{
+		appendSection(stream, "DETAIL");
+		if (!snapshot.selectedObjectSummary.empty())
+		{
+			stream << snapshot.selectedObjectSummary << '\n';
+		}
+		for (const auto &line : snapshot.selectedObjectLines)
+		{
+			stream << line << '\n';
+		}
+	}
+
+	if (!snapshot.warnings.empty())
+	{
+		appendSection(stream, "WARNINGS");
+		for (const auto &warning : snapshot.warnings)
+		{
+			stream << "WARN  " << warning << '\n';
+		}
+	}
+
+	appendSection(stream, "EVENTS");
+	std::vector<InspectEvent> visibleEvents;
+	for (const auto &event : snapshot.events)
+	{
+		if (shouldDisplayEvent(event, verboseEvents))
+		{
+			visibleEvents.push_back(event);
+		}
+	}
+	const auto hiddenByFilterCount = snapshot.events.size() >= visibleEvents.size()
+		? snapshot.events.size() - visibleEvents.size()
+		: 0U;
+
+	const std::size_t maxVisibleEvents = verboseEvents ? kVerboseInspectEventDisplayCount : kDefaultInspectEventDisplayCount;
+	std::size_t hiddenByDisplayLimitCount = 0;
+	if (visibleEvents.size() > maxVisibleEvents)
+	{
+		hiddenByDisplayLimitCount = visibleEvents.size() - maxVisibleEvents;
+		visibleEvents.erase(visibleEvents.begin(), visibleEvents.end() - static_cast<std::ptrdiff_t>(maxVisibleEvents));
+	}
+
+	if (visibleEvents.empty())
+	{
+		stream << "INFO  No live events captured yet.\n";
+	}
+	else
+	{
+		for (const auto &event : visibleEvents)
+		{
+			stream << eventLevelLabel(event.level) << "  " << formatTimestamp(event.timestampMs);
+			if (!event.component.empty())
+			{
+				stream << " [" << event.component << "]";
+			}
+			stream << ' ' << event.message << '\n';
+		}
+	}
+	if (!verboseEvents && hiddenByFilterCount > 0)
+	{
+		stream << "INFO  " << hiddenByFilterCount << " low-signal events hidden; rerun with "
+			<< binaryName << " inspect --live --verbose-events to view them.\n";
+	}
+	if (hiddenByDisplayLimitCount > 0)
+	{
+		stream << "INFO  " << hiddenByDisplayLimitCount << " older visible events hidden to keep the terminal readable.\n";
+	}
+	if (snapshot.droppedEventCount > 0)
+	{
+		stream << "WARN  Event history truncated; " << snapshot.droppedEventCount << " older events were dropped from the ring buffer.\n";
+	}
+
+	if (showTree && !snapshot.objectTreeLines.empty())
+	{
+		appendSection(stream, "TREE");
+		for (const auto &line : snapshot.objectTreeLines)
+		{
+			stream << line << '\n';
+		}
+	}
+
+	appendSection(stream, "NEXT");
+	if (!showTree && !snapshot.objectTreeLines.empty())
+	{
+		stream << "run: " << binaryName << " inspect --live --show-tree\n";
+	}
+	if (!verboseEvents && hiddenByFilterCount > 0)
+	{
+		stream << "run: " << binaryName << " inspect --live --verbose-events\n";
+	}
+	stream << "run: Ctrl-C to stop inspecting\n";
+	return stream.str();
+}
+
+std::string formatMissingSessionReport(const std::string &binaryName)
+{
+	std::ostringstream stream;
+	stream << "BzPeri Inspect\n";
+	stream << "STATUS  FAIL\n";
+	stream << "No managed BzPeri session found.\n";
+
+	appendSection(stream, "WARNINGS");
+	stream << "WARN  " << binaryName << " inspect --live only attaches to sessions launched by "
+		<< binaryName << " demo.\n";
+
+	appendSection(stream, "NEXT");
+	stream << "run: " << binaryName << " demo\n";
+	stream << "run: " << binaryName << " inspect --live\n";
+	return stream.str();
+}
+
+bool isInspectSessionStale(const InspectSessionSnapshot &snapshot, bool (*isProcessAlive)(int pid)) noexcept
+{
+	if (snapshot.pid <= 0)
+	{
+		return true;
+	}
+	if (isProcessAlive == nullptr)
+	{
+		return false;
+	}
+	return !isProcessAlive(snapshot.pid);
+}
+
+std::string formatStaleSessionReport(const InspectSessionSnapshot &snapshot, const std::string &binaryName)
+{
+	std::ostringstream stream;
+	stream << "BzPeri Inspect\n";
+	stream << "STATUS  FAIL\n";
+	stream << "Found a stale managed session file for pid " << snapshot.pid << ".\n";
+
+	appendSection(stream, "WARNINGS");
+	stream << "WARN  The previous " << binaryName << " demo session is no longer running, but its inspect state file still exists.\n";
+
+	appendSection(stream, "NEXT");
+	stream << "run: " << binaryName << " demo\n";
+	stream << "run: " << binaryName << " inspect --live\n";
+	return stream.str();
+}
+
+} // namespace bzp::standalone

--- a/src/StandaloneWorkflow.h
+++ b/src/StandaloneWorkflow.h
@@ -1,0 +1,154 @@
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace bzp::standalone {
+
+enum class Verdict
+{
+	Pass,
+	Warn,
+	Fail,
+};
+
+struct DoctorCheck
+{
+	std::string label;
+	Verdict verdict = Verdict::Fail;
+	std::string detail;
+};
+
+struct DoctorSnapshot
+{
+	bool systemBusReachable = false;
+	std::string systemBusDetail;
+	bool bluezServiceReachable = false;
+	std::string bluezServiceDetail;
+	bool serviceNameAvailable = false;
+	std::string serviceNameDetail;
+	bool adapterProbeSucceeded = false;
+	std::string adapterProbeDetail;
+	bool poweredAdapterAvailable = false;
+	std::string adapterSummary;
+	std::vector<std::string> adapterLines;
+	bool policyInstalled = false;
+	std::string policyPath;
+	bool experimentalHelperAvailable = false;
+	bool experimentalModeEnabled = false;
+	std::string experimentalHelperPath;
+	std::string experimentalDetail;
+};
+
+struct DoctorReport
+{
+	Verdict overall = Verdict::Fail;
+	std::vector<DoctorCheck> checks;
+	std::vector<std::string> adapterLines;
+	std::vector<std::string> nextCommands;
+};
+
+class DoctorProbe
+{
+public:
+	virtual ~DoctorProbe() = default;
+
+	virtual bool checkSystemBus(std::string *detailOut) const = 0;
+	virtual bool checkBluezService(std::string *detailOut) const = 0;
+	virtual bool checkServiceOwnership(const std::string &ownedName, std::string *detailOut) const = 0;
+	virtual bool probeAdapter(const std::string &preferredAdapter,
+		bool *poweredAdapterAvailableOut,
+		std::string *summaryOut,
+		std::vector<std::string> *adapterLinesOut,
+		std::string *detailOut) const = 0;
+	virtual bool checkPolicy(std::string *pathOut) const = 0;
+	virtual bool checkExperimentalHelper(std::string *pathOut, bool *modeEnabledOut, std::string *detailOut) const = 0;
+};
+
+DoctorSnapshot collectDoctorSnapshot(const DoctorProbe &probe, const std::string &preferredAdapter, const std::string &ownedName = "com.bzperi");
+DoctorReport evaluateDoctorSnapshot(const DoctorSnapshot &snapshot, const std::string &binaryName);
+int exitCodeForDoctorReport(const DoctorReport &report) noexcept;
+std::string formatDoctorReport(const DoctorReport &report, const std::string &binaryName);
+std::string verdictLabel(Verdict verdict);
+
+enum class EventLevel
+{
+	Trace,
+	Debug,
+	Info,
+	Status,
+	Warn,
+	Error,
+	Fatal,
+};
+
+struct InspectEvent
+{
+	long long timestampMs = 0;
+	EventLevel level = EventLevel::Info;
+	std::string component;
+	std::string message;
+};
+
+struct InspectSessionSnapshot
+{
+	int formatVersion = 2;
+	int pid = 0;
+	long long updatedAtMs = 0;
+	std::string serviceName;
+	std::string advertisingName;
+	std::string advertisingShortName;
+	std::string sampleNamespace;
+	std::string objectRoot;
+	std::string selectedObjectPath;
+	std::string writeProbePath;
+	std::string selectedObjectSummary;
+	std::string adapterPath;
+	std::string adapterAddress;
+	std::string adapterAlias;
+	bool adapterPowered = false;
+	bool includeSampleServices = true;
+	bool manualLoopMode = false;
+	bool advertisingEnabled = false;
+	int activeConnections = 0;
+	int objectCount = 0;
+	int runState = 0;
+	int health = 0;
+	std::size_t droppedEventCount = 0;
+	std::vector<std::string> objectTreeLines;
+	std::vector<std::string> selectedObjectLines;
+	std::vector<std::string> warnings;
+	std::vector<InspectEvent> events;
+};
+
+class InspectSessionStore
+{
+public:
+	explicit InspectSessionStore(std::string path = defaultSessionPath(), std::size_t eventLimit = 64);
+
+	const std::string &path() const noexcept { return path_; }
+	std::size_t eventLimit() const noexcept { return eventLimit_; }
+
+	bool save(const InspectSessionSnapshot &snapshot, std::string *errorOut = nullptr) const;
+	std::optional<InspectSessionSnapshot> load(std::string *errorOut = nullptr) const;
+	bool clear(std::string *errorOut = nullptr) const;
+
+	static std::string defaultSessionPath();
+
+private:
+	std::string path_;
+	std::size_t eventLimit_;
+};
+
+long long currentTimeMs() noexcept;
+void appendInspectEvent(InspectSessionSnapshot &snapshot, const InspectEvent &event, std::size_t eventLimit);
+bool shouldDisplayEvent(const InspectEvent &event, bool verboseEvents) noexcept;
+std::string eventLevelLabel(EventLevel level);
+std::string formatInspectReport(const InspectSessionSnapshot &snapshot, const std::string &binaryName, bool verboseEvents, bool showTree);
+std::string formatMissingSessionReport(const std::string &binaryName);
+bool isInspectSessionStale(const InspectSessionSnapshot &snapshot, bool (*isProcessAlive)(int pid)) noexcept;
+std::string formatStaleSessionReport(const InspectSessionSnapshot &snapshot, const std::string &binaryName);
+
+} // namespace bzp::standalone

--- a/tests/bzperi_tests.cpp
+++ b/tests/bzperi_tests.cpp
@@ -14,12 +14,14 @@
 #include "../src/BluezAdvertisingSupport.h"
 #include "../src/BluezAdapterCompat.h"
 #include "../src/ServerCompat.h"
+#include "../src/StandaloneWorkflow.h"
 #include "../src/ServerUtils.h"
 #include "../src/StructuredLogger.h"
 
 #include <cstdlib>
 #include <algorithm>
 #include <chrono>
+#include <filesystem>
 #include <exception>
 #include <functional>
 #include <iostream>
@@ -165,6 +167,106 @@ struct LegacyRawCallbackState
 	bool methodCalled = false;
 	bool characteristicReadCalled = false;
 	bool characteristicUpdatedCalled = false;
+};
+
+struct FakeDoctorProbe final : bzp::standalone::DoctorProbe
+{
+	bool systemBusReachable = false;
+	std::string systemBusDetail;
+	bool bluezServiceReachable = false;
+	std::string bluezServiceDetail;
+	bool serviceNameAvailable = false;
+	std::string serviceNameDetail;
+	bool adapterProbeSucceeded = false;
+	bool poweredAdapterAvailable = false;
+	std::string adapterSummary;
+	std::string adapterDetail;
+	bool policyInstalled = false;
+	std::string policyPath;
+	bool helperAvailable = false;
+	bool experimentalModeEnabled = false;
+	std::string helperPath;
+	std::string helperDetail;
+	mutable std::string lastPreferredAdapter;
+
+	bool checkSystemBus(std::string *detailOut) const override
+	{
+		if (detailOut != nullptr)
+		{
+			*detailOut = systemBusDetail;
+		}
+		return systemBusReachable;
+	}
+
+	bool checkBluezService(std::string *detailOut) const override
+	{
+		if (detailOut != nullptr)
+		{
+			*detailOut = bluezServiceDetail;
+		}
+		return bluezServiceReachable;
+	}
+
+	bool checkServiceOwnership(const std::string &, std::string *detailOut) const override
+	{
+		if (detailOut != nullptr)
+		{
+			*detailOut = serviceNameDetail;
+		}
+		return serviceNameAvailable;
+	}
+
+	bool probeAdapter(const std::string &preferredAdapter,
+		bool *poweredAdapterAvailableOut,
+		std::string *summaryOut,
+		std::vector<std::string> *adapterLinesOut,
+		std::string *detailOut) const override
+	{
+		lastPreferredAdapter = preferredAdapter;
+		if (poweredAdapterAvailableOut != nullptr)
+		{
+			*poweredAdapterAvailableOut = poweredAdapterAvailable;
+		}
+		if (summaryOut != nullptr)
+		{
+			*summaryOut = adapterSummary;
+		}
+		if (adapterLinesOut != nullptr)
+		{
+			adapterLinesOut->assign({adapterSummary});
+		}
+		if (detailOut != nullptr)
+		{
+			*detailOut = adapterDetail;
+		}
+		return adapterProbeSucceeded;
+	}
+
+	bool checkPolicy(std::string *pathOut) const override
+	{
+		if (pathOut != nullptr)
+		{
+			*pathOut = policyPath;
+		}
+		return policyInstalled;
+	}
+
+	bool checkExperimentalHelper(std::string *pathOut, bool *modeEnabledOut, std::string *detailOut) const override
+	{
+		if (pathOut != nullptr)
+		{
+			*pathOut = helperPath;
+		}
+		if (modeEnabledOut != nullptr)
+		{
+			*modeEnabledOut = experimentalModeEnabled;
+		}
+		if (detailOut != nullptr)
+		{
+			*detailOut = helperDetail;
+		}
+		return helperAvailable;
+	}
 };
 
 std::vector<std::string> capturedInfoLogs;
@@ -2087,6 +2189,201 @@ void testStructuredLoggerLevelRouting()
 	}
 }
 
+void testStandaloneDoctorReportEvaluation()
+{
+	bzp::standalone::DoctorSnapshot snapshot;
+	snapshot.systemBusReachable = true;
+	snapshot.systemBusDetail = "Connected to the system D-Bus.";
+	snapshot.bluezServiceReachable = true;
+	snapshot.bluezServiceDetail = "org.bluez is present on the system bus.";
+	snapshot.serviceNameAvailable = true;
+	snapshot.serviceNameDetail = "Current process can own com.bzperi on the system bus.";
+	snapshot.adapterProbeSucceeded = true;
+	snapshot.poweredAdapterAvailable = true;
+	snapshot.adapterSummary = "/org/bluez/hci0 powered=yes";
+	snapshot.policyInstalled = true;
+	snapshot.policyPath = "/etc/dbus-1/system.d/com.bzperi.conf";
+	snapshot.experimentalHelperAvailable = true;
+	snapshot.experimentalModeEnabled = true;
+	snapshot.experimentalHelperPath = "/usr/share/bzperi/configure-bluez-experimental.sh";
+
+	const auto report = bzp::standalone::evaluateDoctorSnapshot(snapshot, "bzp-standalone");
+	require(report.overall == bzp::standalone::Verdict::Pass, "Healthy doctor snapshot should evaluate to PASS");
+	require(bzp::standalone::exitCodeForDoctorReport(report) == 0, "Passing doctor report should have exit code 0");
+	require(report.checks.size() == 6, "Doctor report should produce six core checks");
+	require(std::find(report.nextCommands.begin(), report.nextCommands.end(), "bzp-standalone demo") != report.nextCommands.end(),
+		"Passing doctor report should suggest the demo command");
+
+	const auto rendered = bzp::standalone::formatDoctorReport(report, "bzp-standalone");
+	require(rendered.find("STATUS  PASS") != std::string::npos, "Rendered doctor report should include PASS status");
+	require(rendered.find("PASS  Adapter readiness") != std::string::npos, "Rendered doctor report should list adapter readiness");
+}
+
+void testStandaloneDoctorReportWarnsWhenExperimentalModeIsDisabled()
+{
+	bzp::standalone::DoctorSnapshot snapshot;
+	snapshot.systemBusReachable = true;
+	snapshot.systemBusDetail = "Connected to the system D-Bus.";
+	snapshot.bluezServiceReachable = true;
+	snapshot.bluezServiceDetail = "org.bluez is present on the system bus.";
+	snapshot.serviceNameAvailable = true;
+	snapshot.serviceNameDetail = "Current process can own com.bzperi on the system bus.";
+	snapshot.adapterProbeSucceeded = true;
+	snapshot.poweredAdapterAvailable = true;
+	snapshot.adapterSummary = "/org/bluez/hci0 powered=yes";
+	snapshot.policyInstalled = true;
+	snapshot.policyPath = "/etc/dbus-1/system.d/com.bzperi.conf";
+	snapshot.experimentalHelperAvailable = true;
+	snapshot.experimentalModeEnabled = false;
+	snapshot.experimentalHelperPath = "/usr/share/bzperi/configure-bluez-experimental.sh";
+	snapshot.experimentalDetail = "Experimental mode is not enabled.";
+
+	const auto report = bzp::standalone::evaluateDoctorSnapshot(snapshot, "bzp-standalone");
+	require(report.overall == bzp::standalone::Verdict::Warn, "Experimental mode disabled should downgrade doctor to WARN");
+	require(std::find(report.nextCommands.begin(), report.nextCommands.end(),
+		"sudo /usr/share/bzperi/configure-bluez-experimental.sh enable") != report.nextCommands.end(),
+		"Doctor report should suggest enabling experimental mode when the helper says it is disabled");
+}
+
+void testStandaloneDoctorProbeCollection()
+{
+	FakeDoctorProbe probe;
+	probe.systemBusReachable = true;
+	probe.systemBusDetail = "Connected to system bus.";
+	probe.bluezServiceReachable = true;
+	probe.bluezServiceDetail = "org.bluez present.";
+	probe.serviceNameAvailable = false;
+	probe.serviceNameDetail = "Current user cannot own com.bzperi on the system bus.";
+	probe.adapterProbeSucceeded = true;
+	probe.poweredAdapterAvailable = false;
+	probe.adapterSummary = "/org/bluez/hci1 powered=no";
+	probe.adapterDetail = "Adapters found but none are powered.";
+	probe.policyInstalled = false;
+	probe.policyPath = "/etc/dbus-1/system.d/com.bzperi.conf";
+	probe.helperAvailable = true;
+	probe.experimentalModeEnabled = false;
+	probe.helperPath = "/usr/share/bzperi/configure-bluez-experimental.sh";
+	probe.helperDetail = "Experimental mode is not enabled.";
+
+	const auto snapshot = bzp::standalone::collectDoctorSnapshot(probe, "hci1");
+	require(snapshot.systemBusReachable, "Doctor probe collection should preserve the system bus result");
+	require(snapshot.bluezServiceReachable, "Doctor probe collection should preserve the BlueZ service result");
+	require(!snapshot.serviceNameAvailable, "Doctor probe collection should preserve owned-name availability");
+	require(snapshot.adapterProbeSucceeded, "Doctor probe collection should preserve the adapter probe result");
+	require(!snapshot.poweredAdapterAvailable, "Doctor probe collection should preserve powered adapter availability");
+	require(snapshot.adapterSummary == "/org/bluez/hci1 powered=no", "Doctor probe collection should preserve the adapter summary");
+	require(snapshot.adapterLines.size() == 1, "Doctor probe collection should preserve adapter inventory lines");
+	require(snapshot.policyPath == "/etc/dbus-1/system.d/com.bzperi.conf", "Doctor probe collection should preserve the policy path");
+	require(snapshot.experimentalHelperAvailable, "Doctor probe collection should preserve helper availability");
+	require(!snapshot.experimentalModeEnabled, "Doctor probe collection should preserve experimental mode state");
+	require(probe.lastPreferredAdapter == "hci1", "Doctor probe collection should pass the preferred adapter through the seam");
+}
+
+void testInspectSessionStoreRoundTrip()
+{
+	const auto sessionPath = (std::filesystem::temp_directory_path() / "bzperi-inspect-session-test.ini").string();
+	bzp::standalone::InspectSessionStore store(sessionPath, 3);
+
+	bzp::standalone::InspectSessionSnapshot snapshot;
+	snapshot.pid = 4242;
+	snapshot.updatedAtMs = 1000;
+	snapshot.serviceName = "bzperi";
+	snapshot.advertisingName = "BzPeri";
+	snapshot.advertisingShortName = "BzPeri";
+	snapshot.sampleNamespace = "samples";
+	snapshot.objectRoot = "/com/bzperi/samples";
+	snapshot.selectedObjectPath = "/com/bzperi/samples/battery/level";
+	snapshot.writeProbePath = "/com/bzperi/samples/text/string";
+	snapshot.selectedObjectSummary = "selected path: /com/bzperi/samples/battery/level";
+	snapshot.adapterPath = "/org/bluez/hci0";
+	snapshot.adapterAddress = "00:11:22:33:44:55";
+	snapshot.adapterPowered = true;
+	snapshot.objectCount = 4;
+	snapshot.objectTreeLines = {
+		"/com/bzperi/samples [org.bluez.GattService1]",
+		"  /com/bzperi/samples/battery [org.bluez.GattCharacteristic1]",
+	};
+	snapshot.selectedObjectLines = {
+		"interfaces: org.bluez.GattCharacteristic1",
+		"  UUID: '00002a19-0000-1000-8000-00805f9b34fb'",
+	};
+	snapshot.warnings = {"No client is currently connected."};
+
+	bzp::standalone::appendInspectEvent(snapshot, {1001, bzp::standalone::EventLevel::Status, "BluezAdapter", "op=Initialize result=Success"}, 3);
+	bzp::standalone::appendInspectEvent(snapshot, {1002, bzp::standalone::EventLevel::Warn, "BluezAdapter", "adapter powered=no"}, 3);
+	bzp::standalone::appendInspectEvent(snapshot, {1003, bzp::standalone::EventLevel::Info, "BluezAdapter", "op=Connection result=Connected"}, 3);
+	bzp::standalone::appendInspectEvent(snapshot, {1004, bzp::standalone::EventLevel::Debug, "BluezAdapter", "debug noise"}, 3);
+
+	std::string error;
+	require(store.save(snapshot, &error), "Inspect session should save without error: " + error);
+
+	const auto loaded = store.load(&error);
+	require(loaded.has_value(), "Inspect session should load after save");
+	require(loaded->events.size() == 3, "Inspect event buffer should truncate to the configured ring size");
+	require(loaded->events.front().timestampMs == 1002, "Inspect event ring buffer should discard the oldest event");
+	require(loaded->droppedEventCount == 1, "Inspect session should preserve the count of dropped ring-buffer events");
+	require(loaded->writeProbePath == "/com/bzperi/samples/text/string", "Inspect session should round-trip the write probe path");
+	require(loaded->selectedObjectLines.size() == 2, "Inspect selected object lines should round-trip through the session file");
+	require(loaded->objectTreeLines.size() == 2, "Inspect object tree should round-trip through the session file");
+	require(loaded->warnings.size() == 1, "Inspect warnings should round-trip through the session file");
+	require(bzp::standalone::shouldDisplayEvent(loaded->events[0], false), "WARN events should be visible in the default inspect view");
+	require(!bzp::standalone::shouldDisplayEvent(loaded->events.back(), false), "Debug chatter should stay hidden in the default inspect view");
+
+	const auto rendered = bzp::standalone::formatInspectReport(*loaded, "bzp-standalone", false, false);
+	require(rendered.find("BzPeri Inspect") != std::string::npos, "Rendered inspect report should include the inspect header");
+	require(rendered.find("selected object: /com/bzperi/samples/battery/level") != std::string::npos,
+		"Rendered inspect report should include the selected object path");
+	require(rendered.find("write probe: /com/bzperi/samples/text/string") != std::string::npos,
+		"Rendered inspect report should include the write-capable probe path");
+	require(rendered.find("tree: hidden by default") != std::string::npos,
+		"Default inspect report should disclose that the full tree is hidden");
+	require(rendered.find("low-signal events hidden") != std::string::npos,
+		"Default inspect report should disclose filtered low-signal events");
+	require(rendered.find("Event history truncated; 1 older events were dropped") != std::string::npos,
+		"Inspect report should disclose ring-buffer truncation");
+	require(rendered.find("inspect --live --show-tree") != std::string::npos,
+		"Default inspect report should suggest how to reveal the object tree");
+	require(rendered.find("inspect --live --verbose-events") != std::string::npos,
+		"Default inspect report should suggest how to reveal filtered events");
+
+	const auto verboseRendered = bzp::standalone::formatInspectReport(*loaded, "bzp-standalone", true, true);
+	require(verboseRendered.find("\nTREE\n") != std::string::npos,
+		"Inspect report should include the full tree when showTree is requested");
+	require(verboseRendered.find("debug noise") != std::string::npos,
+		"Verbose inspect report should include debug events");
+
+	require(store.clear(&error), "Inspect session store should clear without error: " + error);
+	const auto missing = store.load(&error);
+	require(!missing.has_value(), "Cleared inspect session should no longer load");
+}
+
+bool alwaysAliveForTest(int)
+{
+	return true;
+}
+
+bool neverAliveForTest(int)
+{
+	return false;
+}
+
+void testInspectSessionStaleDetection()
+{
+	bzp::standalone::InspectSessionSnapshot snapshot;
+	snapshot.pid = 99999;
+
+	require(!bzp::standalone::isInspectSessionStale(snapshot, alwaysAliveForTest),
+		"Inspect session should not be stale when the pid probe says it is alive");
+	require(bzp::standalone::isInspectSessionStale(snapshot, neverAliveForTest),
+		"Inspect session should be stale when the pid probe says it is gone");
+	require(bzp::standalone::isInspectSessionStale({}, alwaysAliveForTest),
+		"Inspect session without a pid should be treated as stale");
+
+	const auto rendered = bzp::standalone::formatStaleSessionReport(snapshot, "bzp-standalone");
+	require(rendered.find("stale managed session file") != std::string::npos,
+		"Rendered stale inspect report should explain the stale session");
+}
+
 void testUpdateEnqueueExHelpers()
 {
 	bzpUpdateQueueClear();
@@ -2174,6 +2471,11 @@ int main()
 		{"GLib log capture toggle", testGLibLogCaptureToggle},
 		{"GLib log startup-shutdown mode", testGLibLogCaptureStartupAndShutdownMode},
 		{"Structured logger level routing", testStructuredLoggerLevelRouting},
+		{"Standalone doctor report evaluation", testStandaloneDoctorReportEvaluation},
+		{"Standalone doctor report warns when experimental mode is disabled", testStandaloneDoctorReportWarnsWhenExperimentalModeIsDisabled},
+		{"Standalone doctor probe collection", testStandaloneDoctorProbeCollection},
+		{"Inspect session store round-trip", testInspectSessionStoreRoundTrip},
+		{"Inspect session stale detection", testInspectSessionStaleDetection},
 		{"Update enqueue Ex helpers", testUpdateEnqueueExHelpers},
 	};
 


### PR DESCRIPTION
## Summary
Release target: `v0.2.1`.

**Terminal-first standalone workflow**
- Add a terminal-first `bzp-standalone` control plane with `doctor`, `demo`, and `inspect --live` subcommands.
- Persist managed demo-session state in `StandaloneWorkflow.cpp` so `inspect --live` can render selected objects, warning state, filtered event history, object-tree output, and stale-session guidance.
- Extend unit coverage for doctor report evaluation, the experimental-mode warning path, doctor probe collection, inspect session round-trip persistence, ring-buffer truncation, and stale-session detection.

**Build, packaging, and runtime plumbing**
- Build the new standalone workflow implementation into both `bzp-standalone` and `bzperi-tests`.
- Harden shutdown cleanup in `src/Init.cpp` by only removing GLib sources that are still registered.
- Expand CI verification so Linux builds now assert the new CLI help text, invalid-subcommand failure, no-session inspect failure, installed-binary behavior, and the staged binary's shared-library lookup path.
- Refresh D-Bus policy/helper usage and package-install paths for the new managed workflow.

**Docs and follow-up scaffolding**
- Rewrite first-run docs across `README.md`, `BUILD.md`, `CONTRIBUTING.md`, `BLUEZ_MIGRATION.md`, `README-PACKAGING.md`, and `STANDALONE_USAGE.md` around the `doctor -> demo -> inspect` flow.
- Add `TODOS.md` with follow-up items for external inspector attach support, Raspberry Pi APT packaging, and a future `DESIGN.md` extraction.

## Test Coverage
- Added regression coverage in `tests/bzperi_tests.cpp` for doctor evaluation, doctor warning guidance, doctor probe collection, inspect session persistence, event filtering/truncation disclosure, and stale-session reporting.
- Linux-side validation that I could not run locally on macOS was completed separately on a Raspberry Pi 5 environment.

## Pre-Landing Review
- Manual diff review of the changed CLI/runtime/docs/CI files found no blocking issues.

## Design Review
No frontend files changed, design review skipped.

## Eval Results
No prompt-related files changed, evals skipped.

## Scope Drift
Scope Check: CLEAN.

## Plan Completion
No plan file detected.

## Verification Results
- `git fetch origin main && git merge origin/main --no-edit` -> already up to date with `main`.
- `clang++ -std=c++20 -Iinclude -Isrc -Isamples $(pkg-config --cflags gio-2.0 glib-2.0 gobject-2.0) -c src/StandaloneWorkflow.cpp` -> passed on macOS.
- Linux-only validation that could not be completed locally on macOS was run separately on a Raspberry Pi 5 environment.
- GitHub Actions now re-runs with `fix: set staged library path in CLI verification` so the staged install check can find `libbzp.so` under `DESTDIR`.

## TODOS
- Added `TODOS.md` with follow-up items for external inspector attach, Raspberry Pi APT packaging, and terminal-workflow design rules.

## Test plan
- [x] Sync feature branch with `main`
- [x] Compile smoke check for `src/StandaloneWorkflow.cpp`
- [x] Linux-side validation completed separately on Raspberry Pi 5
- [x] GitHub Actions `Build and Test` workflow rerun after the staged-library-path fix