### PR TITLE
docs: prepare v0.2.1 release notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,4 +127,3 @@ REPORT.md
 # CLI
 CLAUDE.md
 AGENTS.md
-/.gstack/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to BzPeri will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-04-09
+
+This release turns the bundled `bzp-standalone` sample into a terminal-first validation workflow for Linux hosts.
+Compared to `v0.2.0`, the focus here is getting from "the library built" to "the full host/demo/inspect path is working"
+with fewer manual steps and stronger packaged-install verification.
+
+### Added
+- Terminal-first `bzp-standalone` subcommands:
+  - `doctor` for host-readiness checks and adapter inventory
+  - `demo` for the managed sample BLE server path
+  - `inspect --live` for reading managed-session state without scraping stdout
+- Managed inspect-session persistence and reporting, including selected-object context, object-tree output, event history,
+  low-signal filtering, and stale-session guidance
+- Regression coverage for doctor evaluation, doctor probe collection, inspect-session persistence, event filtering, ring-buffer
+  truncation, and stale-session detection
+- `TODOS.md` follow-up tracking for inspector expansion, Raspberry Pi packaging, and terminal workflow design rules
+
+### Changed
+- The standalone sample, build docs, contributor docs, packaging docs, and usage guide now lead with the
+  `doctor -> demo -> inspect` workflow
+- Standalone build/test targets now compile the shared workflow implementation into both `bzp-standalone` and `bzperi-tests`
+- CI executable verification now checks subcommand help text, invalid-subcommand handling, no-session inspect behavior, and
+  installed-binary behavior
+- The BlueZ experimental helper now checks the running `bluetoothd` process first and resolves the effective `ExecStart` from
+  the active systemd unit before falling back to heuristics
+
+### Fixed
+- D-Bus policy rules now allow the `com.bzperi.*` service-prefix ownership and debug/introspection flow used by the managed
+  standalone workflow
+- Shutdown cleanup now removes GLib sources only when they are still registered with the active main context
+- Installed-binary CI verification now exports the staged library path before executing `bzp-standalone` from `DESTDIR`
+
 ## [0.2.0] - 2026-03-13
 
 This release is the first `0.2.x` line and is the largest functional update since `0.1.9`.
@@ -161,6 +193,7 @@ cmake -DENABLE_LEGACY_SINGLETON_COMPAT=OFF -DENABLE_LEGACY_RAW_GLIB_COMPAT=OFF
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| 0.2.1 | 2026-04-09 | Terminal-first standalone workflow, live inspect session reports, CI/install verification hardening |
 | 0.2.0 | 2026-03-13 | Runtime hardening, manual run loop, Ex APIs, GLib capture/power controls |
 | 0.1.9 | 2025-11-14 | Debian 12 arm64 container builds |
 | 0.1.7 | 2025-11-14 | GLIBCXX/Debian 12 compatibility |

--- a/README.md
+++ b/README.md
@@ -72,16 +72,15 @@ BzPeri is a C++20 Bluetooth LE GATT server framework that makes creating BLE ser
 - **Robust error handling** - Detailed result codes and defensive runtime checks
 - **Secure by default** - Proper bonding/pairing support out of the box
 
-## New in v0.2.0
+## New in v0.2.1
 
-Compared to the `0.1.x` line, `v0.2.0` is primarily a runtime/API maturity release rather than a packaging-only update.
+Compared to `v0.2.0`, `v0.2.1` is about making first-run validation feel like a complete product path instead of a pile of flags.
 
-- **Manual run-loop support**: host applications can run BzPeri without the internal server thread and integrate it into an external event loop.
-- **Detailed `Ex` APIs**: startup, wait, shutdown, GLib capture, update queue, and run-loop helpers now have result-code variants instead of ambiguous `0/1` or `void` behavior.
-- **Compatibility isolation**: deprecated singleton/global and raw GLib callback layers can now be compiled out with CMake options.
-- **BlueZ runtime hardening**: better adapter recovery, reconnect behavior, advertising payload selection, and runtime state logging.
-- **Operational controls**: GLib capture modes/targets/domains, power-management hooks, and optional sleep inhibitor support were added for embedded hosts.
-- **Regression coverage**: the project now ships a `ctest` unit/regression target, and the sample/runtime paths have been exercised against real BLE clients.
+- **Terminal-first standalone workflow**: `bzp-standalone doctor`, `demo`, and `inspect --live` now form the primary validation path.
+- **Live inspect session reports**: the managed demo writes session state that `inspect --live` can read back as object metadata, recent events, and next-step guidance.
+- **Packaged-install verification**: CI now checks both the build-tree binary and the staged installed binary, so release packaging regressions get caught before tagging.
+- **Workflow-oriented docs**: README, build docs, packaging docs, and standalone usage docs now all walk through the same `doctor -> demo -> inspect` flow.
+- **Linux host hardening**: the BlueZ experimental helper and D-Bus policy now better match real packaged installs and multi-name service usage.
 
 ## Upgrading from v0.1.x
 
@@ -169,7 +168,7 @@ int main() {
 
 ### For Users
 - **[API Reference](include/BzPeri.h)** - Complete API documentation
-- **[Changelog](CHANGELOG.md)** - Release-by-release summary, including `v0.2.0` vs `v0.1.x`
+- **[Changelog](CHANGELOG.md)** - Release-by-release summary for the current `v0.2.1` line and earlier milestones
 - **[Configurator API](include/bzp/ConfiguratorSupport.h)** - Modern service configuration API
 - **[Compatibility Migration](COMPATIBILITY_MIGRATION.md)** - Deprecated API migration from Gobbledegook and legacy BzPeri shims
 - **[Standalone Usage](STANDALONE_USAGE.md)** - Command-line options and adapter selection guide


### PR DESCRIPTION
## Summary
Release target: `v0.2.1`.

- add the `0.2.1` changelog entry for the terminal-first standalone workflow release
- update the README's top-level release section to point at `v0.2.1`
- remove the temporary local ignore entry that should not ride along with the release follow-up

## Test plan
- [x] docs and release metadata only
- [x] no runtime or packaging code changed in this follow-up
